### PR TITLE
Refactor ES code and message parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.dll
 *.so
 *.dylib
-ingest
+ingest/ingest
 
 # Log files
 logs/
@@ -40,3 +40,4 @@ claude.md
 
 # MegaStream Test Data
 ingest/test_data/megastream
+ingest/test_data/parquet

--- a/ingest/elasticsearch.go
+++ b/ingest/elasticsearch.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v9"
+)
+
+// ElasticsearchDoc represents the document structure for indexing
+type ElasticsearchDoc struct {
+	AtURI            string               `json:"at_uri"`
+	AuthorDID        string               `json:"author_did"`
+	Content          string               `json:"content"`
+	CreatedAt        string               `json:"created_at"`
+	ThreadRootPost   string               `json:"thread_root_post,omitempty"`
+	ThreadParentPost string               `json:"thread_parent_post,omitempty"`
+	QuotePost        string               `json:"quote_post,omitempty"`
+	Embeddings       map[string][]float32 `json:"embeddings,omitempty"`
+	IndexedAt        string               `json:"indexed_at"`
+}
+
+// ElasticsearchConfig holds configuration for Elasticsearch connection
+type ElasticsearchConfig struct {
+	URL           string
+	APIKey        string
+	SkipTLSVerify bool
+}
+
+// NewElasticsearchClient creates and tests a new Elasticsearch client
+func NewElasticsearchClient(config ElasticsearchConfig, logger *IngestLogger) (*elasticsearch.Client, error) {
+	esConfig := elasticsearch.Config{
+		Addresses: []string{config.URL},
+		APIKey:    config.APIKey,
+	}
+
+	if config.SkipTLSVerify {
+		logger.Info("TLS certificate verification disabled (local development mode)")
+		esConfig.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+	}
+
+	client, err := elasticsearch.NewClient(esConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Elasticsearch client: %w", err)
+	}
+
+	res, err := client.Info()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Elasticsearch: %w", err)
+	}
+	res.Body.Close()
+
+	logger.Info("Connected to Elasticsearch at %s", config.URL)
+	return client, nil
+}
+
+// bulkIndex indexes a batch of documents to Elasticsearch
+func bulkIndex(ctx context.Context, client *elasticsearch.Client, index string, docs []ElasticsearchDoc, dryRun bool, logger *IngestLogger) error {
+	if len(docs) == 0 {
+		return nil
+	}
+
+	if dryRun {
+		logger.Debug("Dry-run: Skipping bulk index of %d documents to index '%s'", len(docs), index)
+		return nil
+	}
+
+	var buf bytes.Buffer
+
+	for _, doc := range docs {
+		meta := map[string]interface{}{
+			"index": map[string]interface{}{
+				"_index": index,
+				"_id":    doc.AtURI,
+			},
+		}
+
+		metaJSON, err := json.Marshal(meta)
+		if err != nil {
+			return fmt.Errorf("failed to marshal metadata: %w", err)
+		}
+
+		buf.Write(metaJSON)
+		buf.WriteByte('\n')
+
+		docJSON, err := json.Marshal(doc)
+		if err != nil {
+			return fmt.Errorf("failed to marshal document: %w", err)
+		}
+
+		buf.Write(docJSON)
+		buf.WriteByte('\n')
+	}
+
+	res, err := client.Bulk(
+		bytes.NewReader(buf.Bytes()),
+		client.Bulk.WithContext(ctx),
+	)
+	if err != nil {
+		return fmt.Errorf("bulk request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.IsError() {
+		return fmt.Errorf("bulk request returned error: %s", res.String())
+	}
+
+	var bulkResponse struct {
+		Errors bool `json:"errors"`
+		Items  []map[string]struct {
+			Error *struct {
+				Type   string `json:"type"`
+				Reason string `json:"reason"`
+			} `json:"error"`
+		} `json:"items"`
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&bulkResponse); err != nil {
+		return fmt.Errorf("failed to parse bulk response: %w", err)
+	}
+
+	if bulkResponse.Errors {
+		itemsJSON, _ := json.Marshal(bulkResponse.Items)
+		logger.Error("Bulk indexing failed with errors. Response items: %s", string(itemsJSON))
+		return fmt.Errorf("bulk indexing failed: some documents had errors (see logs for details)")
+	}
+
+	return nil
+}
+
+// CreateElasticsearchDoc creates an ElasticsearchDoc from a MegaStreamMessage
+func CreateElasticsearchDoc(msg MegaStreamMessage) ElasticsearchDoc {
+	return ElasticsearchDoc{
+		AtURI:            msg.GetAtURI(),
+		AuthorDID:        msg.GetAuthorDID(),
+		Content:          msg.GetContent(),
+		CreatedAt:        msg.GetCreatedAt(),
+		ThreadRootPost:   msg.GetThreadRootPost(),
+		ThreadParentPost: msg.GetThreadParentPost(),
+		QuotePost:        msg.GetQuotePost(),
+		Embeddings:       msg.GetEmbeddings(),
+		IndexedAt:        time.Now().UTC().Format(time.RFC3339),
+	}
+}

--- a/ingest/main.go
+++ b/ingest/main.go
@@ -1,40 +1,17 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"crypto/tls"
 	"database/sql"
-	"encoding/base64"
-	"encoding/binary"
-	"encoding/json"
 	"flag"
-	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
-	"github.com/elastic/go-elasticsearch/v9"
 	_ "modernc.org/sqlite"
 )
 
-// TODO: Move to multithreaded implementation with DataSource interface abstraction
-// This will support multiple data sources: WebSocket, local SQLite, and S3-hosted SQLite
-
-// ElasticsearchDoc represents the document structure for indexing
-type ElasticsearchDoc struct {
-	AtURI            string               `json:"at_uri"`
-	AuthorDID        string               `json:"author_did"`
-	Content          string               `json:"content"`
-	CreatedAt        string               `json:"created_at"`
-	ThreadRootPost   string               `json:"thread_root_post,omitempty"`
-	ThreadParentPost string               `json:"thread_parent_post,omitempty"`
-	QuotePost        string               `json:"quote_post,omitempty"`
-	Embeddings       map[string][]float32 `json:"embeddings,omitempty"`
-	IndexedAt        string               `json:"indexed_at"`
-}
+// TODO: Move to multithreaded implementation
 
 func main() {
 	// Parse command line flags
@@ -82,35 +59,17 @@ func main() {
 	}()
 
 	// Initialize Elasticsearch client
-	esConfig := elasticsearch.Config{
-		Addresses: []string{config.ElasticsearchURL},
-		APIKey:    config.ElasticsearchAPIKey,
+	esConfig := ElasticsearchConfig{
+		URL:           config.ElasticsearchURL,
+		APIKey:        config.ElasticsearchAPIKey,
+		SkipTLSVerify: *skipTLSVerify,
 	}
 
-	// Configure TLS settings if skip verification is requested
-	if *skipTLSVerify {
-		logger.Info("TLS certificate verification disabled (local development mode)")
-		esConfig.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		}
-	}
-
-	esClient, err := elasticsearch.NewClient(esConfig)
+	esClient, err := NewElasticsearchClient(esConfig, logger)
 	if err != nil {
-		logger.Error("Failed to create Elasticsearch client: %v", err)
+		logger.Error("%v", err)
 		os.Exit(1)
 	}
-
-	// Test Elasticsearch connection
-	res, err := esClient.Info()
-	if err != nil {
-		logger.Error("Failed to connect to Elasticsearch: %v", err)
-		os.Exit(1)
-	}
-	res.Body.Close()
-	logger.Info("Connected to Elasticsearch at %s", config.ElasticsearchURL)
 
 	// Open SQLite database
 	db, err := sql.Open("sqlite", config.SQLiteDBPath)
@@ -153,107 +112,16 @@ func main() {
 			continue
 		}
 
-		// TODO: Create common implementation for message structure and deserialization
-		// This should replace the JSON parsing code in both pipeline.go and main.go
+		msg := NewMegaStreamMessage(atURI, did, rawPostJSON, inferencesJSON, logger)
 
-		// Parse raw_post JSON
-		var rawPost map[string]interface{}
-		if err := json.Unmarshal([]byte(rawPostJSON), &rawPost); err != nil {
-			logger.Error("Failed to parse raw_post JSON for %s: %v", atURI, err)
-			continue
-		}
-
-		// Check for delete operation
-		message, ok := rawPost["message"].(map[string]interface{})
-		if !ok {
-			logger.Debug("No message field in raw_post for %s", atURI)
-			continue
-		}
-
-		commit, ok := message["commit"].(map[string]interface{})
-		if !ok {
-			logger.Debug("No commit field in message for %s", atURI)
-			continue
-		}
-
-		operation, _ := commit["operation"].(string)
 		// TODO: Handle post deletions in Elasticsearch instead of skipping
 		// We should delete or mark as deleted in ES when operation == "delete"
-		if operation == "delete" {
+		if msg.IsDelete() {
 			skippedCount++
 			continue
 		}
 
-		// Extract record data
-		record, ok := commit["record"].(map[string]interface{})
-		if !ok {
-			logger.Debug("No record field in commit for %s", atURI)
-			continue
-		}
-
-		// Extract content
-		content, _ := record["text"].(string)
-
-		// Extract createdAt
-		createdAt, _ := record["createdAt"].(string)
-
-		// Parse hydrated_metadata for thread/quote info
-		hydratedMetadata, _ := rawPost["hydrated_metadata"].(map[string]interface{})
-
-		var threadRootPost, threadParentPost, quotePost string
-
-		if hydratedMetadata != nil {
-			if replyPost, ok := hydratedMetadata["reply_post"].(map[string]interface{}); ok {
-				threadRootPost, _ = replyPost["uri"].(string)
-			}
-
-			if parentPost, ok := hydratedMetadata["parent_post"].(map[string]interface{}); ok {
-				threadParentPost, _ = parentPost["uri"].(string)
-			}
-
-			if qPost, ok := hydratedMetadata["quote_post"].(map[string]interface{}); ok {
-				quotePost, _ = qPost["uri"].(string)
-			}
-		}
-
-		// Parse inferences JSON for embeddings
-		var inferences map[string]interface{}
-		embeddings := make(map[string][]float32)
-
-		if err := json.Unmarshal([]byte(inferencesJSON), &inferences); err == nil {
-			if textEmbeddings, ok := inferences["text_embeddings"].(map[string]interface{}); ok {
-				// Decode all-MiniLM-L12-v2 embeddings
-				if embL12, ok := textEmbeddings["all-MiniLM-L12-v2"].(string); ok {
-					if decoded, err := decodeEmbedding(embL12); err == nil {
-						embeddings["all_MiniLM_L12_v2"] = decoded
-					} else {
-						logger.Debug("Failed to decode L12 embedding for %s: %v", atURI, err)
-					}
-				}
-
-				// Decode all-MiniLM-L6-v2 embeddings
-				if embL6, ok := textEmbeddings["all-MiniLM-L6-v2"].(string); ok {
-					if decoded, err := decodeEmbedding(embL6); err == nil {
-						embeddings["all_MiniLM_L6_v2"] = decoded
-					} else {
-						logger.Debug("Failed to decode L6 embedding for %s: %v", atURI, err)
-					}
-				}
-			}
-		}
-
-		// Create Elasticsearch document
-		doc := ElasticsearchDoc{
-			AtURI:            atURI,
-			AuthorDID:        did,
-			Content:          content,
-			CreatedAt:        createdAt,
-			ThreadRootPost:   threadRootPost,
-			ThreadParentPost: threadParentPost,
-			QuotePost:        quotePost,
-			Embeddings:       embeddings,
-			IndexedAt:        time.Now().UTC().Format(time.RFC3339),
-		}
+		doc := CreateElasticsearchDoc(msg)
 
 		batch = append(batch, doc)
 
@@ -294,108 +162,4 @@ cleanup:
 	}
 
 	logger.Info("Ingestion complete. Processed: %d, Skipped: %d", processedCount, skippedCount)
-}
-
-// decodeEmbedding decodes a base64-encoded embedding string to float32 array
-func decodeEmbedding(encoded string) ([]float32, error) {
-	// TODO: The embeddings appear to be custom encoded, not standard base64;
-	// we need to check with Graze for appropriate encoding function.
-	decoded, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil {
-		return nil, fmt.Errorf("base64 decode failed: %w", err)
-	}
-
-	// Convert bytes to float32 array
-	floatCount := len(decoded) / 4
-	floats := make([]float32, floatCount)
-
-	for i := range floatCount {
-		bits := binary.LittleEndian.Uint32(decoded[i*4 : (i+1)*4])
-		floats[i] = float32(bits)
-	}
-
-	return floats, nil
-}
-
-// TODO: Move Elasticsearch indexing code to separate file implementing ElasticsearchClient from interfaces.go
-// This will allow for better separation of concerns and easier testing
-
-// bulkIndex indexes a batch of documents to Elasticsearch
-func bulkIndex(ctx context.Context, client *elasticsearch.Client, index string, docs []ElasticsearchDoc, dryRun bool, logger *IngestLogger) error {
-	if len(docs) == 0 {
-		return nil
-	}
-
-	// In dry-run mode, skip the actual write operation
-	if dryRun {
-		logger.Debug("Dry-run: Skipping bulk index of %d documents to index '%s'", len(docs), index)
-		return nil
-	}
-
-	var buf bytes.Buffer
-
-	for _, doc := range docs {
-		// Add index action
-		meta := map[string]interface{}{
-			"index": map[string]interface{}{
-				"_index": index,
-				"_id":    doc.AtURI,
-			},
-		}
-
-		metaJSON, err := json.Marshal(meta)
-		if err != nil {
-			return fmt.Errorf("failed to marshal metadata: %w", err)
-		}
-
-		buf.Write(metaJSON)
-		buf.WriteByte('\n')
-
-		// Add document
-		docJSON, err := json.Marshal(doc)
-		if err != nil {
-			return fmt.Errorf("failed to marshal document: %w", err)
-		}
-
-		buf.Write(docJSON)
-		buf.WriteByte('\n')
-	}
-
-	// Perform bulk request
-	res, err := client.Bulk(
-		bytes.NewReader(buf.Bytes()),
-		client.Bulk.WithContext(ctx),
-	)
-	if err != nil {
-		return fmt.Errorf("bulk request failed: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.IsError() {
-		return fmt.Errorf("bulk request returned error: %s", res.String())
-	}
-
-	// Parse the response to check for individual document errors
-	var bulkResponse struct {
-		Errors bool `json:"errors"`
-		Items  []map[string]struct {
-			Error *struct {
-				Type   string `json:"type"`
-				Reason string `json:"reason"`
-			} `json:"error"`
-		} `json:"items"`
-	}
-
-	if err := json.NewDecoder(res.Body).Decode(&bulkResponse); err != nil {
-		return fmt.Errorf("failed to parse bulk response: %w", err)
-	}
-
-	// If any documents had errors, log details and return error
-	if bulkResponse.Errors {
-		itemsJSON, _ := json.Marshal(bulkResponse.Items)
-		logger.Error("Bulk indexing failed with errors. Response items: %s", string(itemsJSON))
-		return fmt.Errorf("bulk indexing failed: some documents had errors (see logs for details)")
-	}
-
-	return nil
 }

--- a/ingest/message.go
+++ b/ingest/message.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+)
+
+// MegaStreamMessage defines the interface for processing messages from the MegaStream database
+type MegaStreamMessage interface {
+	GetAtURI() string
+	GetAuthorDID() string
+	GetContent() string
+	GetCreatedAt() string
+	GetThreadRootPost() string
+	GetThreadParentPost() string
+	GetQuotePost() string
+	GetEmbeddings() map[string][]float32
+	IsDelete() bool
+}
+
+// megaStreamMessage is the implementation of MegaStreamMessage
+type megaStreamMessage struct {
+	atURI            string
+	did              string
+	content          string
+	createdAt        string
+	threadRootPost   string
+	threadParentPost string
+	quotePost        string
+	embeddings       map[string][]float32
+	isDelete         bool
+	parseError       error
+}
+
+// NewMegaStreamMessage creates a new MegaStreamMessage from raw SQLite data
+func NewMegaStreamMessage(atURI, did, rawPostJSON, inferencesJSON string, logger *IngestLogger) MegaStreamMessage {
+	msg := &megaStreamMessage{
+		atURI:      atURI,
+		did:        did,
+		embeddings: make(map[string][]float32),
+	}
+
+	msg.parseRawPost(rawPostJSON, logger)
+	msg.parseInferences(inferencesJSON, logger)
+
+	return msg
+}
+
+// parseRawPost parses the raw_post JSON and extracts relevant fields
+func (m *megaStreamMessage) parseRawPost(rawPostJSON string, logger *IngestLogger) {
+	var rawPost map[string]interface{}
+	if err := json.Unmarshal([]byte(rawPostJSON), &rawPost); err != nil {
+		m.parseError = fmt.Errorf("failed to parse raw_post JSON: %w", err)
+		logger.Error("Failed to parse raw_post JSON for %s: %v", m.atURI, err)
+		return
+	}
+
+	message, ok := rawPost["message"].(map[string]interface{})
+	if !ok {
+		logger.Debug("No message field in raw_post for %s", m.atURI)
+		return
+	}
+
+	commit, ok := message["commit"].(map[string]interface{})
+	if !ok {
+		logger.Debug("No commit field in message for %s", m.atURI)
+		return
+	}
+
+	operation, _ := commit["operation"].(string)
+	if operation == "delete" {
+		m.isDelete = true
+		return
+	}
+
+	record, ok := commit["record"].(map[string]interface{})
+	if !ok {
+		logger.Debug("No record field in commit for %s", m.atURI)
+		return
+	}
+
+	m.content, _ = record["text"].(string)
+	m.createdAt, _ = record["createdAt"].(string)
+
+	hydratedMetadata, _ := rawPost["hydrated_metadata"].(map[string]interface{})
+	if hydratedMetadata != nil {
+		if replyPost, ok := hydratedMetadata["reply_post"].(map[string]interface{}); ok {
+			m.threadRootPost, _ = replyPost["uri"].(string)
+		}
+
+		if parentPost, ok := hydratedMetadata["parent_post"].(map[string]interface{}); ok {
+			m.threadParentPost, _ = parentPost["uri"].(string)
+		}
+
+		if qPost, ok := hydratedMetadata["quote_post"].(map[string]interface{}); ok {
+			m.quotePost, _ = qPost["uri"].(string)
+		}
+	}
+}
+
+// parseInferences parses the inferences JSON and extracts embeddings
+func (m *megaStreamMessage) parseInferences(inferencesJSON string, logger *IngestLogger) {
+	var inferences map[string]interface{}
+	if err := json.Unmarshal([]byte(inferencesJSON), &inferences); err != nil {
+		logger.Debug("Failed to parse inferences JSON for %s: %v", m.atURI, err)
+		return
+	}
+
+	textEmbeddings, ok := inferences["text_embeddings"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	if embL12, ok := textEmbeddings["all-MiniLM-L12-v2"].(string); ok {
+		if decoded, err := decodeEmbedding(embL12); err == nil {
+			m.embeddings["all_MiniLM_L12_v2"] = decoded
+		} else {
+			logger.Debug("Failed to decode L12 embedding for %s: %v", m.atURI, err)
+		}
+	}
+
+	if embL6, ok := textEmbeddings["all-MiniLM-L6-v2"].(string); ok {
+		if decoded, err := decodeEmbedding(embL6); err == nil {
+			m.embeddings["all_MiniLM_L6_v2"] = decoded
+		} else {
+			logger.Debug("Failed to decode L6 embedding for %s: %v", m.atURI, err)
+		}
+	}
+}
+
+// decodeEmbedding decodes a base64-encoded embedding string to float32 array
+func decodeEmbedding(encoded string) ([]float32, error) {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode failed: %w", err)
+	}
+
+	floatCount := len(decoded) / 4
+	floats := make([]float32, floatCount)
+
+	for i := range floatCount {
+		bits := binary.LittleEndian.Uint32(decoded[i*4 : (i+1)*4])
+		floats[i] = float32(bits)
+	}
+
+	return floats, nil
+}
+
+// Interface method implementations
+
+func (m *megaStreamMessage) GetAtURI() string {
+	return m.atURI
+}
+
+func (m *megaStreamMessage) GetAuthorDID() string {
+	return m.did
+}
+
+func (m *megaStreamMessage) GetContent() string {
+	return m.content
+}
+
+func (m *megaStreamMessage) GetCreatedAt() string {
+	return m.createdAt
+}
+
+func (m *megaStreamMessage) GetThreadRootPost() string {
+	return m.threadRootPost
+}
+
+func (m *megaStreamMessage) GetThreadParentPost() string {
+	return m.threadParentPost
+}
+
+func (m *megaStreamMessage) GetQuotePost() string {
+	return m.quotePost
+}
+
+func (m *megaStreamMessage) GetEmbeddings() map[string][]float32 {
+	return m.embeddings
+}
+
+func (m *megaStreamMessage) IsDelete() bool {
+	return m.isDelete
+}


### PR DESCRIPTION
## Changes in This PR

This PR performs refactors to make the code easier to read and extend. Specifically:
- Refactor the ES client connection and document indexing logic to a separate file and interface
- Refactor the Megastream event JSON parsing code into its own file and interface
- Update main.go to use those new interfaces

## Testing

I'm going to test in a stacked branch so I only have to test once (since testing is a bit expensive at the moment since it's done manually).