### PR TITLE
Add AWS credentials to S3Spooler client

### DIFF
--- a/ingest/config.go
+++ b/ingest/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	SpoolIntervalSec  int
 	SpoolStateFile    string
 	AWSRegion         string
+	AWSS3AccessKey    string
+	AWSS3SecretKey    string
 
 	// Logging configuration
 	LoggingEnabled bool
@@ -51,6 +53,8 @@ func LoadConfig() *Config {
 		SpoolIntervalSec:     getEnvInt("SPOOL_INTERVAL_SEC", 60),
 		SpoolStateFile:       getEnv("SPOOL_STATE_FILE", ".processed_files.json"),
 		AWSRegion:            getEnv("AWS_REGION", "us-east-1"),
+		AWSS3AccessKey:       getEnv("AWS_S3_ACCESS_KEY", ""),
+		AWSS3SecretKey:       getEnv("AWS_S3_SECRET_KEY", ""),
 		LoggingEnabled:       getEnvBool("LOGGING_ENABLED", true),
 	}
 }

--- a/ingest/main.go
+++ b/ingest/main.go
@@ -113,7 +113,7 @@ func runIngestion(ctx context.Context, config *Config, logger *IngestLogger, sou
 	if source == "local" {
 		spooler = NewLocalSpooler(config.LocalSQLiteDBPath, mode, interval, stateManager, logger)
 	} else {
-		spooler, err = NewS3Spooler(config.S3SQLiteDBBucket, config.S3SQLiteDBPrefix, config.AWSRegion, mode, interval, stateManager, logger)
+		spooler, err = NewS3Spooler(config.S3SQLiteDBBucket, config.S3SQLiteDBPrefix, config.AWSRegion, config.AWSS3AccessKey, config.AWSS3SecretKey, mode, interval, stateManager, logger)
 		if err != nil {
 			logger.Error("Failed to create S3 spooler: %v", err)
 			os.Exit(1)

--- a/ingest/spooler.go
+++ b/ingest/spooler.go
@@ -68,8 +68,25 @@ func NewLocalSpooler(directory string, mode string, interval time.Duration, stat
 	}
 }
 
-func NewS3Spooler(bucket, prefix, region string, mode string, interval time.Duration, stateManager *StateManager, logger *IngestLogger) (*S3Spooler, error) {
-	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
+func NewS3Spooler(bucket, prefix, region, accessKey, secretKey string, mode string, interval time.Duration, stateManager *StateManager, logger *IngestLogger) (*S3Spooler, error) {
+	var cfg aws.Config
+	var err error
+
+	if accessKey != "" && secretKey != "" {
+		cfg, err = config.LoadDefaultConfig(
+			context.Background(),
+			config.WithRegion(region),
+			config.WithCredentialsProvider(aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+				return aws.Credentials{
+					AccessKeyID:     accessKey,
+					SecretAccessKey: secretKey,
+				}, nil
+			})),
+		)
+	} else {
+		cfg, err = config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}


### PR DESCRIPTION
Closes #31 

# This PR

Quick add-on to #41 to include AWS credentials from the environment for authentication. 

# Testing

```
./ingest --mode=once --skip-tls-verify --source=s3 > logs/2025-10-29-test-s3.txt 2>&1
```

Confirm querying, loading, and ingesting files from megastream S3 buckets is successful against local ES instance.

Output: [2025-10-29-test-s3.txt](https://github.com/user-attachments/files/23222475/2025-10-29-test-s3.txt)