### PR TITLE
Index post text content

### DIFF
--- a/index/deploy/k8s/environments/local/templates/posts-index-template.yaml
+++ b/index/deploy/k8s/environments/local/templates/posts-index-template.yaml
@@ -32,6 +32,7 @@ data:
             },
             "content": {
               "type": "text",
+              "index": true
               "analyzer": "content_analyzer",
               "fields": {
                 "raw": {

--- a/index/deploy/k8s/environments/stage/templates/posts-index-template.yaml
+++ b/index/deploy/k8s/environments/stage/templates/posts-index-template.yaml
@@ -32,6 +32,7 @@ data:
             },
             "content": {
               "type": "text",
+              "index": true
               "analyzer": "content_analyzer",
               "fields": {
                 "raw": {


### PR DESCRIPTION
Closes #3 

# This PR

I forgot to add the `index: true` flag to the post content field. This PR adds the field so post content is indexed as text, enabling full-text search in elastic search.

# Testing

Redeploy local ES instance and re-ingest data from local files; confirm ingest is successful.