### PR TITLE
Reduce prod cluster size

### DIFF
--- a/index/deploy.sh
+++ b/index/deploy.sh
@@ -246,7 +246,7 @@ setup_kubectl_context() {
                         --location="$GKE_REGION" \
                         --project="$GKE_PROJECT_ID" \
                         --machine-type="n2-highmem-2" \
-                        --num-nodes=15 \
+                        --num-nodes=4 \
                         --node-labels=workload=es-data \
                         --disk-size=100 \
                         --disk-type=pd-standard \

--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -59,7 +59,7 @@ patches:
         path: /spec/nodeSets/-
         value:
           name: data
-          count: 15
+          count: 4
           config:
             node.roles: ["data", "ingest"]
             node.store.allow_mmap: true


### PR DESCRIPTION
Closes #102 

## This PR

- Reduce number of VM nodes and ES nodes from 15 -> 4, keeping resources on each VM the same. 

See original quant analysis that led us to 15 in https://github.com/greenearth-social/ingex/issues/37#issuecomment-3524922085.

Note: a large amount of manual [work is required to increase shard count](https://www.elastic.co/search-labs/blog/elasticsearch-increase-primary-shard-count), whereas much [less work is required to reduce shard count](https://www.elastic.co/docs/deploy-manage/production-guidance/optimize-performance/size-shards#shrink-existing-index-to-fewer-shards), so we err on the side of maintaining the existing shard count and placing more shards on each node instead of reducing the resources on each node.

## Testing

We'll test when we're ready to deploy the environment.