### PR TITLE
Fix go ci not running on base branch change

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -8,6 +8,11 @@ on:
       - '.github/workflows/go-ci.yml'
   pull_request:
     branches: [ main, develop ]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
     paths:
       - 'ingest/**'
       - '.github/workflows/go-ci.yml'


### PR DESCRIPTION
See title. This PR effectively adds the 'edited' type to the pull_request event type. This will cause the CI to re-run any time someone edits the base branch of a PR to point to main. Missing this caused CI to not run on #124 when I changed the base branch from another feature to main.

Note: the 'edited' type will also cause CI to run when someone edits the PR title/description, but we don't have many PRs so I doubt we'll exceed 'free tier' capacity and our CI is fast (for now) so better safe than sorry.