### PR TITLE
Handle different time string formats consistently with UTC

### DIFF
--- a/ingest/internal/common/jetstream_message.go
+++ b/ingest/internal/common/jetstream_message.go
@@ -77,9 +77,13 @@ func (m *jetstreamMessage) parseRawEvent(rawJSON string, logger *IngestLogger) {
 				}
 			}
 
-			// Extract created_at timestamp
-			if createdAt, ok := event.Commit.Record["createdAt"].(string); ok {
-				m.createdAt = createdAt
+			// Extract and normalize created_at timestamp to UTC
+			if rawCreatedAt, ok := event.Commit.Record["createdAt"].(string); ok {
+				m.createdAt = NormalizeTimestampToUTC(rawCreatedAt, logger)
+				if m.createdAt == "" {
+					logger.Error("Failed to normalize createdAt timestamp for at_uri: %s (raw value: %s)", m.uri, rawCreatedAt)
+					return
+				}
 			} else {
 				logger.Error("Failed to extract createdAt from Jetstream JSON (at_uri: %s)", m.uri)
 				return

--- a/ingest/internal/common/megastream_message.go
+++ b/ingest/internal/common/megastream_message.go
@@ -102,7 +102,9 @@ func (m *megaStreamMessage) parseRawPost(rawPostJSON string, logger *IngestLogge
 	}
 
 	m.content, _ = record["text"].(string)
-	m.createdAt, _ = record["createdAt"].(string)
+	if rawCreatedAt, ok := record["createdAt"].(string); ok {
+		m.createdAt = NormalizeTimestampToUTC(rawCreatedAt, logger)
+	}
 
 	hydratedMetadata, _ := rawPost["hydrated_metadata"].(map[string]interface{})
 	if hydratedMetadata != nil {

--- a/ingest/internal/common/timestamp.go
+++ b/ingest/internal/common/timestamp.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"time"
+)
+
+// NormalizeTimestampToUTC parses an RFC3339/ISO 8601 timestamp string and
+// returns it normalized to UTC in RFC3339 format.
+// Returns empty string and logs error if parsing fails.
+func NormalizeTimestampToUTC(timestamp string, logger *IngestLogger) string {
+	if timestamp == "" {
+		return ""
+	}
+
+	// Parse the timestamp (handles RFC3339 with timezone offsets)
+	parsedTime, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		// Try with nanoseconds variant (ISO 8601 with more precision)
+		parsedTime, err = time.Parse(time.RFC3339Nano, timestamp)
+		if err != nil {
+			logger.Error("Failed to parse timestamp '%s': %v", timestamp, err)
+			return ""
+		}
+	}
+
+	// Convert to UTC and format back to RFC3339
+	return parsedTime.UTC().Format(time.RFC3339)
+}

--- a/ingest/internal/common/timestamp_test.go
+++ b/ingest/internal/common/timestamp_test.go
@@ -1,0 +1,75 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestNormalizeTimestampToUTC(t *testing.T) {
+	logger := NewLogger(false)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		isError  bool
+	}{
+		{
+			name:     "already UTC with Z suffix",
+			input:    "2025-01-27T12:34:56Z",
+			expected: "2025-01-27T12:34:56Z",
+			isError:  false,
+		},
+		{
+			name:     "timezone offset +05:00 converts to UTC",
+			input:    "2025-01-27T17:34:56+05:00",
+			expected: "2025-01-27T12:34:56Z",
+			isError:  false,
+		},
+		{
+			name:     "timezone offset -08:00 converts to UTC",
+			input:    "2025-01-27T04:34:56-08:00",
+			expected: "2025-01-27T12:34:56Z",
+			isError:  false,
+		},
+		{
+			name:     "nanosecond precision with Z",
+			input:    "2025-01-27T12:34:56.789123Z",
+			expected: "2025-01-27T12:34:56Z",
+			isError:  false,
+		},
+		{
+			name:     "nanosecond precision with offset",
+			input:    "2025-01-27T17:34:56.789123+05:00",
+			expected: "2025-01-27T12:34:56Z",
+			isError:  false,
+		},
+		{
+			name:     "empty string returns empty",
+			input:    "",
+			expected: "",
+			isError:  false,
+		},
+		{
+			name:     "invalid format returns empty and logs error",
+			input:    "2025-01-27 12:34:56",
+			expected: "",
+			isError:  true,
+		},
+		{
+			name:     "malformed timestamp returns empty",
+			input:    "not-a-timestamp",
+			expected: "",
+			isError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeTimestampToUTC(tt.input, logger)
+			if result != tt.expected {
+				t.Errorf("NormalizeTimestampToUTC(%q) = %q, expected %q",
+					tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #117 

## This PR

This PR creates a consistent mechanism for handling raw time strings from Mega/Jetstream (which are formatted differently depending on source) and converting them to UTC before storage.

## Testing

### Unit Tests

Create tests for handling various timestamp format strings. Run tests before impl and observe failure, then again after impl and observe success.

**Before**
```
=== RUN   TestJetstreamMessage_TimeUs
--- PASS: TestJetstreamMessage_TimeUs (0.00s)
=== RUN   TestJetstreamMessage_CreatedAtNormalization
=== RUN   TestJetstreamMessage_CreatedAtNormalization/UTC_timestamp_preserved
=== RUN   TestJetstreamMessage_CreatedAtNormalization/timezone_offset_+05:00_normalized_to_UTC
    jetstream_message_test.go:316: GetCreatedAt() = "2025-01-27T17:00:00+05:00", expected "2025-01-27T12:00:00Z"
=== RUN   TestJetstreamMessage_CreatedAtNormalization/nanosecond_precision_normalized
    jetstream_message_test.go:316: GetCreatedAt() = "2025-01-27T12:00:00.789123Z", expected "2025-01-27T12:00:00Z"
--- FAIL: TestJetstreamMessage_CreatedAtNormalization (0.00s)
    --- PASS: TestJetstreamMessage_CreatedAtNormalization/UTC_timestamp_preserved (0.00s)
    --- FAIL: TestJetstreamMessage_CreatedAtNormalization/timezone_offset_+05:00_normalized_to_UTC (0.00s)
    --- FAIL: TestJetstreamMessage_CreatedAtNormalization/nanosecond_precision_normalized (0.00s)
=== RUN   TestMegaStreamMessage_CreatedAtNormalization
=== RUN   TestMegaStreamMessage_CreatedAtNormalization/UTC_timestamp_preserved
=== RUN   TestMegaStreamMessage_CreatedAtNormalization/timezone_offset_+05:00_normalized_to_UTC
    megastream_message_test.go:228: GetCreatedAt() = "2025-01-27T17:00:00+05:00", expected "2025-01-27T12:00:00Z"
=== RUN   TestMegaStreamMessage_CreatedAtNormalization/timezone_offset_-08:00_normalized_to_UTC
    megastream_message_test.go:228: GetCreatedAt() = "2025-01-27T04:00:00-08:00", expected "2025-01-27T12:00:00Z"
--- FAIL: TestMegaStreamMessage_CreatedAtNormalization (0.00s)
    --- PASS: TestMegaStreamMessage_CreatedAtNormalization/UTC_timestamp_preserved (0.00s)
    --- FAIL: TestMegaStreamMessage_CreatedAtNormalization/timezone_offset_+05:00_normalized_to_UTC (0.00s)
    --- FAIL: TestMegaStreamMessage_CreatedAtNormalization/timezone_offset_-08:00_normalized_to_UTC (0.00s)
```

**After**: All tests pass.

### Integration Test

Run megastream and jetstream ingest locally with --no-rewind for ~1 hour. Go to kibana and use ES|QL to confirm both likes and posts have populated data in that hour.

<img width="1495" height="538" alt="Screenshot 2025-12-21 at 4 55 54 PM" src="https://github.com/user-attachments/assets/524fce3f-aacc-4db2-b685-b32332c507fe" />
<img width="1906" height="411" alt="Screenshot 2025-12-21 at 4 56 38 PM" src="https://github.com/user-attachments/assets/66369d86-2485-4e4b-a15e-5ac936490417" />
<img width="1908" height="643" alt="Screenshot 2025-12-21 at 4 56 51 PM" src="https://github.com/user-attachments/assets/3bffe4fd-fb71-40c9-810f-86c476f19239" />
<img width="1909" height="336" alt="Screenshot 2025-12-21 at 4 56 56 PM" src="https://github.com/user-attachments/assets/4141beeb-dcbd-48d5-8d5c-582023bb3ae9" />

