### PR TITLE
Half hourly extract

### DIFF
--- a/ingest/scripts/deploy.sh
+++ b/ingest/scripts/deploy.sh
@@ -267,9 +267,9 @@ deploy_extract_job() {
     local destination_bucket
 
     max_records=1000000      # 1M records
-    window_minutes=65       # ~1 hours
+    window_minutes=33       # ~1/2 hour
     indices="posts,likes"
-    log_info "$GE_ENVIRONMENT environment: 1M max records, approx. 1-hour window, indices: posts,likes"
+    log_info "$GE_ENVIRONMENT environment: 1M max records, approx. 30 min window, indices: posts,likes"
     destination_bucket="$GE_GCP_PROJECT_ID-ingex-extract-$GE_ENVIRONMENT"
 
     # Prepare source directory (similar to expiry job)

--- a/ingest/scripts/gcp_setup.sh
+++ b/ingest/scripts/gcp_setup.sh
@@ -422,10 +422,10 @@ setup_extract_cloud_scheduler() {
         return 0
     fi
 
-    local schedule="0 * * * *"  # Every 1 hour at the top of the hour
-    local job_name="extract-hourly-stage"
-    local description="hourly extract job for stage"
-    log_info "Stage environment: Configuring hourly extract schedule"
+    local schedule="*/30 * * * *"  # Every 1/2 hour at the top and middle of the hour
+    local job_name="extract-halfhourly-stage"
+    local description="Half hourly extract job for stage"
+    log_info "Stage environment: Configuring half hourly extract schedule"
 
     # Grant the default compute service account permission to invoke the Cloud Run job
     log_info "Granting default compute service account permission to invoke extract job..."


### PR DESCRIPTION
## This PR

Run extract job every 30 minutes instead of 1 hour to ease memory demand.

This should help with OOMs in #148 until I have a moment to implement and test a cursor/pagination/buffer based approach.

## Testing

Run deploy and gcp_setup scripts to deploy the 30min extract schedule.