### PR TITLE
Update emergency data clear scripts

### DIFF
--- a/ingest/scripts/fix_es_readonly.sh
+++ b/ingest/scripts/fix_es_readonly.sh
@@ -11,7 +11,7 @@ if [ -z "$GE_ELASTICSEARCH_API_KEY" ]; then
 fi
 
 echo "Removing read-only block from all indices..."
-curl -X PUT "${GE_ELASTICSEARCH_URL}/_all/_settings" \
+curl -k -X PUT "${GE_ELASTICSEARCH_URL}/_all/_settings" \
   -H "Authorization: ApiKey ${GE_ELASTICSEARCH_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -20,10 +20,10 @@ curl -X PUT "${GE_ELASTICSEARCH_URL}/_all/_settings" \
 
 echo ""
 echo "Checking cluster status..."
-curl -X GET "${GE_ELASTICSEARCH_URL}/_cluster/health?pretty" \
+curl -k -X GET "${GE_ELASTICSEARCH_URL}/_cluster/health?pretty" \
   -H "Authorization: ApiKey ${GE_ELASTICSEARCH_API_KEY}"
 
 echo ""
 echo "Checking disk usage..."
-curl -X GET "${GE_ELASTICSEARCH_URL}/_cat/allocation?v&h=node,disk.used_percent,disk.used,disk.avail,disk.total" \
+curl -k -X GET "${GE_ELASTICSEARCH_URL}/_cat/allocation?v&h=node,disk.used_percent,disk.used,disk.avail,disk.total" \
   -H "Authorization: ApiKey ${GE_ELASTICSEARCH_API_KEY}"


### PR DESCRIPTION
## This PR

I had to clear the index and read-only flag on our stage ES indices due to #179. I hit a couple bugs in the scripts. This PR fixes them:
- Allow skipping TLS for curl requests in the scripts since we're making these connections to ES over port-forwarded secure connections anyway
- Replace duplicated code that creates our indices with a message about how to use the "source of truth" code for index recreation. This is already implemented in `index/deploy.sh` (and it became outdated after #178)

## Testing

Used these scripts to fix overflowing ES indexes this evening.