### PR TITLE
Double storage for data pods

### DIFF
--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -74,7 +74,7 @@ patches:
               - ReadWriteOnce
               resources:
                 requests:
-                  storage: 256Gi
+                  storage: 512Gi
   - target:
       kind: Kibana
       name: greenearth


### PR DESCRIPTION
Before deploy:

```
=================================================
Target Environment: prod
Target Namespace:   greenearth-prod
=================================================
Continue with this environment? (y/N): y
Proceeding with prod environment...

Checking disk space for all Elasticsearch pods...
=================================================
Pod: greenearth-es-data-0
  Total: 251G | Used: 106G | Available: 146G | Use%: 42%

Pod: greenearth-es-data-1
  Total: 251G | Used: 105G | Available: 146G | Use%: 42%

Pod: greenearth-es-data-2
  Total: 251G | Used: 105G | Available: 147G | Use%: 42%

Pod: greenearth-es-data-3
  Total: 251G | Used: 106G | Available: 146G | Use%: 43%

Pod: greenearth-es-master-0
  Total: 16G | Used: 724K | Available: 16G | Use%: 1%

Pod: greenearth-es-master-1
  Total: 16G | Used: 724K | Available: 16G | Use%: 1%
```

After deploy (within 5 min):

```
=================================================
Target Environment: prod
Target Namespace:   greenearth-prod
=================================================
Continue with this environment? (y/N): y
Proceeding with prod environment...

Checking disk space for all Elasticsearch pods...
=================================================
Pod: greenearth-es-data-0
  Total: 503G | Used: 106G | Available: 398G | Use%: 21%

Pod: greenearth-es-data-1
  Total: 503G | Used: 106G | Available: 398G | Use%: 21%

Pod: greenearth-es-data-2
  Total: 503G | Used: 105G | Available: 399G | Use%: 21%

Pod: greenearth-es-data-3
  Total: 503G | Used: 106G | Available: 398G | Use%: 21%

Pod: greenearth-es-master-0
  Total: 16G | Used: 724K | Available: 16G | Use%: 1%

Pod: greenearth-es-master-1
  Total: 16G | Used: 724K | Available: 16G | Use%: 1%
```