### PR TITLE
Double stage storage

### DIFF
--- a/index/deploy/k8s/environments/stage/kustomization.yaml
+++ b/index/deploy/k8s/environments/stage/kustomization.yaml
@@ -35,7 +35,7 @@ patches:
         value: "-Xms4g -Xmx4g"
       - op: replace
         path: /spec/nodeSets/0/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 32Gi
+        value: 64Gi
       - op: add
         path: /spec/nodeSets/-
         value:
@@ -66,7 +66,7 @@ patches:
               - ReadWriteOnce
               resources:
                 requests:
-                  storage: 32Gi
+                  storage: 64Gi
   - target:
       kind: Kibana
       name: greenearth


### PR DESCRIPTION
## This PR

While working on #193 I realized disk utilization was >90% on stage. Due to uneven balancing of data across nodes, one of the node was basically at 99% capacity.

This PR fixes this by:

- Double storage capacity on stage

## Testing

Deploy on stage and observe storage utilization halved.

<img width="947" height="356" alt="Screenshot 2026-02-04 at 2 38 10 PM" src="https://github.com/user-attachments/assets/4bb4b872-fb2a-48ec-abfc-5c673f51d762" />
