### PR TITLE
Add Elasticsearch Prometheus exporter for GKE monitoring

### DIFF
--- a/index/deploy/k8s/base/elasticsearch-exporter.yaml
+++ b/index/deploy/k8s/base/elasticsearch-exporter.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch-exporter
+  labels:
+    app.kubernetes.io/name: elasticsearch-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: elasticsearch-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: elasticsearch-exporter
+    spec:
+      containers:
+        - name: elasticsearch-exporter
+          image: quay.io/prometheuscommunity/elasticsearch-exporter:v1.8.0
+          args:
+            - --es.uri=https://$(ES_USERNAME):$(ES_PASSWORD)@greenearth-es-http:9200
+            - --es.ssl-skip-verify
+            - --es.all
+          env:
+            - name: ES_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: es-service-user-secret
+                  key: username
+            - name: ES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: es-service-user-secret
+                  key: password
+          ports:
+            - name: prometheus
+              containerPort: 9114
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: prometheus
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: prometheus
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+              cpu: 100m

--- a/index/deploy/k8s/base/kustomization.yaml
+++ b/index/deploy/k8s/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - elasticsearch-internal-lb.yaml
   - kibana.yaml
   - deployment-state-configmap.yaml
+  - elasticsearch-exporter.yaml
   - templates/posts-index-template.yaml
   - templates/post-tombstones-index-template.yaml
   - templates/likes-index-template.yaml

--- a/index/deploy/k8s/environments/prod/elasticsearch-pod-monitoring.yaml
+++ b/index/deploy/k8s/environments/prod/elasticsearch-pod-monitoring.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: elasticsearch-exporter
+  labels:
+    app.kubernetes.io/name: elasticsearch-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: elasticsearch-exporter
+  endpoints:
+    - port: prometheus
+      path: /metrics
+      interval: 30s

--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: greenearth-prod
 
 resources:
   - ../../base
+  - elasticsearch-pod-monitoring.yaml
   - max-map-count-daemonset.yaml
 
 patches:

--- a/index/deploy/k8s/environments/stage/elasticsearch-pod-monitoring.yaml
+++ b/index/deploy/k8s/environments/stage/elasticsearch-pod-monitoring.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: elasticsearch-exporter
+  labels:
+    app.kubernetes.io/name: elasticsearch-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: elasticsearch-exporter
+  endpoints:
+    - port: prometheus
+      path: /metrics
+      interval: 30s

--- a/index/deploy/k8s/environments/stage/kustomization.yaml
+++ b/index/deploy/k8s/environments/stage/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: greenearth-stage
 
 resources:
   - ../../base
+  - elasticsearch-pod-monitoring.yaml
   - max-map-count-daemonset.yaml
 
 patches:


### PR DESCRIPTION
Closes #225

The ingest services are falling behind the live data stream with no visibility into whether ES is the bottleneck. Since ES runs on GKE Autopilot via ECK, the GCP Ops Agent (designed for Compute Engine VMs) is not applicable. This PR uses the GKE-native approach: Elasticsearch Prometheus Exporter + GKE Managed Service for Prometheus, which is Google's official recommendation for ES metrics on GKE.

# This PR

Adds Elasticsearch resource utilization metrics to GCP Metric Explorer via Prometheus. Specifically:

- Add elasticsearch-exporter Deployment (quay.io/prometheuscommunity/elasticsearch-exporter:v1.8.0) to base kustomization, using existing es-service-user credentials
- Add PodMonitoring CRD for GKE Managed Prometheus in stage and prod environments (not local/minikube where the CRD doesn't exist)
- Exporter scrapes all node stats (CPU, memory, disk I/O, JVM, thread pools, cache, indices) on port 9114 at 30s intervals

# Testing

- Kustomize dry-run for all environments: `kubectl kustomize index/deploy/k8s/environments/{local,stage,prod}`
- Deploy to stage: `index/deploy.sh stage --ctypes resource`
- Verify exporter pod: `kubectl get pods -n greenearth-stage -l app.kubernetes.io/name=elasticsearch-exporter`
- Verify metrics: `kubectl port-forward -n greenearth-stage deploy/elasticsearch-exporter 9114` then `curl localhost:9114/metrics`
- Verify in GCP Metric Explorer: check for `prometheus.googleapis.com/elasticsearch_*` metrics

<img width="1143" height="751" alt="Screenshot 2026-02-06 at 1 13 01 PM" src="https://github.com/user-attachments/assets/b2eef30e-8bfa-4110-91e1-1f5c1de64b4e" />
