### PR TITLE
Stage: separate node roles; prod: double data CPU; ES indexing optimizations

### DIFF
--- a/index/deploy/k8s/base/templates/hashtags-index-template.yaml
+++ b/index/deploy/k8s/base/templates/hashtags-index-template.yaml
@@ -9,7 +9,10 @@ data:
       "template": {
         "settings": {
           "number_of_shards": $(HASHTAG_INDEX_SHARDS),
-          "number_of_replicas": $(HASHTAG_INDEX_REPLICAS)
+          "number_of_replicas": $(HASHTAG_INDEX_REPLICAS),
+          "refresh_interval": "30s",
+          "translog.durability": "async",
+          "translog.sync_interval": "30s"
         },
         "mappings": {
           "properties": {

--- a/index/deploy/k8s/base/templates/like-tombstones-index-template.yaml
+++ b/index/deploy/k8s/base/templates/like-tombstones-index-template.yaml
@@ -9,7 +9,10 @@ data:
       "template": {
         "settings": {
           "number_of_shards": $(INDEX_SHARDS),
-          "number_of_replicas": $(INDEX_REPLICAS)
+          "number_of_replicas": $(INDEX_REPLICAS),
+          "refresh_interval": "30s",
+          "translog.durability": "async",
+          "translog.sync_interval": "30s"
         },
         "mappings": {
           "_routing": {

--- a/index/deploy/k8s/base/templates/likes-index-template.yaml
+++ b/index/deploy/k8s/base/templates/likes-index-template.yaml
@@ -9,7 +9,10 @@ data:
       "template": {
         "settings": {
           "number_of_shards": $(INDEX_SHARDS),
-          "number_of_replicas": $(INDEX_REPLICAS)
+          "number_of_replicas": $(INDEX_REPLICAS),
+          "refresh_interval": "30s",
+          "translog.durability": "async",
+          "translog.sync_interval": "30s"
         },
         "mappings": {
           "_routing": {

--- a/index/deploy/k8s/base/templates/post-tombstones-index-template.yaml
+++ b/index/deploy/k8s/base/templates/post-tombstones-index-template.yaml
@@ -9,7 +9,10 @@ data:
       "template": {
         "settings": {
           "number_of_shards": $(INDEX_SHARDS),
-          "number_of_replicas": $(INDEX_REPLICAS)
+          "number_of_replicas": $(INDEX_REPLICAS),
+          "refresh_interval": "30s",
+          "translog.durability": "async",
+          "translog.sync_interval": "30s"
         },
         "mappings": {
           "_routing": {

--- a/index/deploy/k8s/base/templates/posts-index-template.yaml
+++ b/index/deploy/k8s/base/templates/posts-index-template.yaml
@@ -10,6 +10,9 @@ data:
         "settings": {
           "number_of_shards": $(INDEX_SHARDS),
           "number_of_replicas": $(INDEX_REPLICAS),
+          "refresh_interval": "30s",
+          "translog.durability": "async",
+          "translog.sync_interval": "30s",
           "analysis": {
             "analyzer": {
               "content_analyzer": {

--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -60,10 +60,10 @@ patches:
                 resources:
                   requests:
                     memory: 12Gi
-                    cpu: "1500m"
+                    cpu: "3000m"
                   limits:
                     memory: 12Gi
-                    cpu: "1500m"
+                    cpu: "3000m"
                 env:
                 - name: ES_JAVA_OPTS
                   value: "-Xms5g -Xmx5g"

--- a/index/deploy/k8s/environments/stage/kustomization.yaml
+++ b/index/deploy/k8s/environments/stage/kustomization.yaml
@@ -15,35 +15,43 @@ patches:
     patch: |-
       - op: replace
         path: /spec/nodeSets/0/name
-        value: master-data
+        value: master
+      - op: replace
+        path: /spec/nodeSets/0/count
+        value: 2
+      - op: replace
+        path: /spec/nodeSets/0/config
+        value:
+          node.roles: ["master"]
+          node.store.allow_mmap: true
       - op: add
         path: /spec/nodeSets/0/config/node.store.allow_mmap
         value: true
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/requests/memory
-        value: 12Gi
+        value: 2Gi
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/limits/memory
-        value: 12Gi
+        value: 2Gi
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/requests/cpu
-        value: "2500m"
+        value: "250m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/limits/cpu
-        value: "2500m"
+        value: "250m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/env/0/value
-        value: "-Xms6g -Xmx6g"
+        value: "-Xms1g -Xmx1g"
       - op: replace
         path: /spec/nodeSets/0/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 32Gi
+        value: 8Gi
       - op: add
         path: /spec/nodeSets/-
         value:
-          name: data-only
-          count: 1
+          name: data
+          count: 2
           config:
-            node.roles: ["data"]
+            node.roles: ["data", "ingest"]
             node.store.allow_mmap: true
           podTemplate:
             spec:
@@ -51,14 +59,14 @@ patches:
               - name: elasticsearch
                 resources:
                   requests:
-                    memory: 12Gi
-                    cpu: "2500m"
+                    memory: 10Gi
+                    cpu: "2250m"
                   limits:
-                    memory: 12Gi
-                    cpu: "2500m"
+                    memory: 10Gi
+                    cpu: "2250m"
                 env:
                 - name: ES_JAVA_OPTS
-                  value: "-Xms6g -Xmx6g"
+                  value: "-Xms5g -Xmx5g"
           volumeClaimTemplates:
           - metadata:
               name: elasticsearch-data


### PR DESCRIPTION
Stage and prod ES clusters are CPU-constrained during peak hours, causing ingest to fall behind data streams. Stage's hybrid master-data node maxes out CPU; prod data nodes hover at ~100% CPU.

# This PR

Addresses ES cluster CPU constraints on stage and prod to keep ingest from falling behind. Specifically:

- **Stage**: Replace hybrid master-data + data-only topology (1+1 nodes) with dedicated master (2x 250m/2Gi) + dedicated data (2x 2250m/10Gi) nodes, keeping roughly the same total resource envelope (this way things match prod and support easier rolling updates for master nodes in the future)
- **Prod**: Double data node CPU from 1500m → 3000m (requests and limits)
- **Both environments**: Add ES indexing speed optimizations to all 5 index templates — `refresh_interval: 30s` (delays search result consistency), `translog.durability: async` (async consistency across replicas), `translog.sync_interval: 30s` (interval at which to trigger async replication)

# Testing

- `cd ingest && go test -v ./...` — all tests pass
- `cd ingest && golangci-lint run` — 0 issues
- `kubectl kustomize environments/stage` and `environments/prod` — both render successfully
- Deploy stage ES: 
    - `index/deploy.sh stage --no-timeout --ctypes resource && index/deploy.sh stage --no-timeout --ctypes schema`
- Deploy prod ES: 
    - `index/deploy.sh prod --no-timeout --ctypes resource && index/deploy.sh prod --no-timeout --ctypes schema`
- Observe CPU utilization and ingest lag after deployment