### PR TITLE
Expand resources stage/prod

### DIFF
--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -60,13 +60,13 @@ patches:
                 resources:
                   requests:
                     memory: 12Gi
-                    cpu: "3000m"
+                    cpu: "6000m"
                   limits:
                     memory: 12Gi
-                    cpu: "3000m"
+                    cpu: "6000m"
                 env:
                 - name: ES_JAVA_OPTS
-                  value: "-Xms5g -Xmx5g"
+                  value: "-Xms6g -Xmx6g"
           volumeClaimTemplates:
           - metadata:
               name: elasticsearch-data
@@ -75,7 +75,7 @@ patches:
               - ReadWriteOnce
               resources:
                 requests:
-                  storage: 512Gi
+                  storage: 1024Gi
   - target:
       kind: Kibana
       name: greenearth

--- a/index/deploy/k8s/environments/stage/kustomization.yaml
+++ b/index/deploy/k8s/environments/stage/kustomization.yaml
@@ -35,10 +35,10 @@ patches:
         value: 2Gi
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/requests/cpu
-        value: "250m"
+        value: "500m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/limits/cpu
-        value: "250m"
+        value: "500m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/env/0/value
         value: "-Xms1g -Xmx1g"


### PR DESCRIPTION
Part of #221 

## This PR

- Double prod CPU capacity
- Bump stage CPU capacity slightly for master nodes
- Double prod storage capacity

## Testing

- Deploy to stage: `./index/deploy.sh stage --ctypes resource`
- Deploy to prod: `./index/deploy.sh prod --ctypes resource`