### PR TITLE
Double stage storage

### DIFF
--- a/index/deploy/k8s/environments/stage/kustomization.yaml
+++ b/index/deploy/k8s/environments/stage/kustomization.yaml
@@ -75,7 +75,7 @@ patches:
               - ReadWriteOnce
               resources:
                 requests:
-                  storage: 32Gi
+                  storage: 64Gi
   - target:
       kind: Kibana
       name: greenearth


### PR DESCRIPTION
Stage is on track to exceed capacity overnight. The trend seems unexpected given half-hourly expiration, so I feel like something is amiss, however expiry and ingest both seem to be running fine. Let's see what the morning brings. We can reduce storage later if we're incorrectly ingesting/deleting data.

<img width="911" height="314" alt="Screenshot 2026-02-16 at 10 20 34 PM" src="https://github.com/user-attachments/assets/801d7cbf-2e24-4e90-8abc-1d09bd85e974" />
