### PR TITLE
Bump prod master mem, data mem/cpu slightly

### DIFF
--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -29,10 +29,10 @@ patches:
         value: true
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/requests/memory
-        value: 4Gi
+        value: 6Gi
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/limits/memory
-        value: 4Gi
+        value: 6Gi
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/requests/cpu
         value: "1000m"
@@ -41,7 +41,7 @@ patches:
         value: "1000m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/env/0/value
-        value: "-Xms2g -Xmx2g"
+        value: "-Xms3g -Xmx3g"
       - op: replace
         path: /spec/nodeSets/0/volumeClaimTemplates/0/spec/resources/requests/storage
         value: 16Gi
@@ -59,14 +59,14 @@ patches:
               - name: elasticsearch
                 resources:
                   requests:
-                    memory: 12Gi
-                    cpu: "6000m"
+                    memory: 16Gi
+                    cpu: "8000m"
                   limits:
-                    memory: 12Gi
-                    cpu: "6000m"
+                    memory: 16Gi
+                    cpu: "8000m"
                 env:
                 - name: ES_JAVA_OPTS
-                  value: "-Xms6g -Xmx6g"
+                  value: "-Xms8g -Xmx8g"
           volumeClaimTemplates:
           - metadata:
               name: elasticsearch-data


### PR DESCRIPTION
Part of #221 

Links:
- [Ingest Dashboard](https://console.cloud.google.com/monitoring/dashboards/builder/037af1ef-21a3-49e2-8c90-97d65362063a;duration=P3D?project=greenearth-471522)
- [Elastic Search Dasboard](https://console.cloud.google.com/monitoring/dashboards/builder/112222be-42ce-4bad-a012-7b4822585831;endTime=2026-02-18T02:00:00.000Z;filters=var:Cluster,val:greenearth-prod-cluster%2Bvar:Location%2Bvar:Namespace;startTime=2026-02-17T16:00:00.000Z?project=greenearth-471522)

## Issue

Prod is keeping pace on everything but jetstream ingest. Jetstream ingest on prod is in a loop of falling behind then recovering as it processes peak periods of data.

<img width="1445" height="341" alt="Screenshot 2026-02-18 at 11 47 24 AM" src="https://github.com/user-attachments/assets/b650a9b4-6620-408c-a541-c004c57696ea" />

Our dashboards show (unlike stage) memory circuit breakers are being tripped for prod and some intermittent CPU max utilization (correlated with latency in ES API). Also, looks like memory utilization on stage is lower, and since stage is able to keep up with ingest, that may be a sign prod needs more mem.

<img width="732" height="225" alt="Screenshot 2026-02-18 at 11 53 47 AM" src="https://github.com/user-attachments/assets/aa6d4599-beaa-4a66-be85-ac143c689e3c" />
<img width="1444" height="337" alt="Screenshot 2026-02-18 at 11 54 12 AM" src="https://github.com/user-attachments/assets/d0c45b99-4998-4ad4-984b-0427ab2cfe16" />
<img width="1450" height="340" alt="Screenshot 2026-02-18 at 11 58 36 AM" src="https://github.com/user-attachments/assets/63994a64-a8e0-4484-a375-2e0bedbc7a19" />



## This PR

Since bumping cpu moved us in the right direction for ingest freshness previously (moving from consistent lag to periods of lag/recovery), this PR takes one final stab at increasing resources on prod (cpu/mem) to see if we can keep jetstream under control.