### PR TITLE
Reduce rate limit threshold

### DIFF
--- a/ingest/scripts/deploy.sh
+++ b/ingest/scripts/deploy.sh
@@ -214,6 +214,7 @@ deploy_jetstream_service() {
         --set-env-vars="GE_GCP_PROJECT_ID=$GE_GCP_PROJECT_ID" \
         --set-env-vars="GE_GCP_REGION=$GE_GCP_REGION" \
         --set-env-vars="GE_BLOCKLIST_DESTINATION=gs://$GE_GCP_PROJECT_ID-ingex-blocklist-$GE_ENVIRONMENT" \
+        --set-env-vars="GE_LIKE_RATE_LIMIT_PER_HOUR=1200" \
         --set-secrets="GE_ELASTICSEARCH_API_KEY=$es_api_key_secret:latest" \
         --scaling="$GE_JETSTREAM_INSTANCES" \
         --cpu=1 \


### PR DESCRIPTION
Follow up from #259. Default 2000 likes per hour per account isn't filtering much. Reduce rate limit to 1200 likes per hour per account.

<img width="1860" height="374" alt="Screenshot 2026-02-28 at 10 12 25 AM" src="https://github.com/user-attachments/assets/9197123c-8c78-44f5-bba4-29a46cd26862" />
