### PR TITLE
Reduce like rate limit

### DIFF
--- a/ingest/scripts/deploy.sh
+++ b/ingest/scripts/deploy.sh
@@ -214,7 +214,7 @@ deploy_jetstream_service() {
         --set-env-vars="GE_GCP_PROJECT_ID=$GE_GCP_PROJECT_ID" \
         --set-env-vars="GE_GCP_REGION=$GE_GCP_REGION" \
         --set-env-vars="GE_BLOCKLIST_DESTINATION=gs://$GE_GCP_PROJECT_ID-ingex-blocklist-$GE_ENVIRONMENT" \
-        --set-env-vars="GE_LIKE_RATE_LIMIT_PER_HOUR=1200" \
+        --set-env-vars="GE_LIKE_RATE_LIMIT_PER_HOUR=600" \
         --set-secrets="GE_ELASTICSEARCH_API_KEY=$es_api_key_secret:latest" \
         --scaling="$GE_JETSTREAM_INSTANCES" \
         --cpu=1 \


### PR DESCRIPTION
Part of #221 

## Context

Follow up from #265. Reducing rate limit to 1200 likes/hr/account on feb 28 @ 10am relatively reduced lag occurences, but we're still seeing a pretty low rate limit filter rate and occasional lag as a result.

<img width="1851" height="672" alt="Screenshot 2026-03-06 at 2 34 31 PM" src="https://github.com/user-attachments/assets/66e5e57f-763e-4d7a-82c8-7c4a3007de7d" />

## This PR

Reduce like rate limit threshold further to 600 likes/hr/account. This is equivalent to 50 likes/5 min/account or 10 likes/min/account which still seems reasonable for organic likes/accounts (but we probably won't go lower).