### PR TITLE
Fix bug where jetstream cursor was not updated

### DIFF
--- a/ingest/cmd/jetstream_ingest/main.go
+++ b/ingest/cmd/jetstream_ingest/main.go
@@ -290,6 +290,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 						if err := stateManager.UpdateCursor(pendingCursor); err != nil {
 							logger.Error("Failed to flush final cursor update: %v", err)
 						}
+						client.UpdateCursor(pendingCursor)
 					}
 					cursorMu.Unlock()
 					return
@@ -300,6 +301,10 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 							logger.Error("Failed to update cursor: %v", err)
 						} else {
 							hasPendingUpdate = false
+							// Keep the client's reconnection cursor in sync so that
+							// WebSocket reconnects resume from the latest processed
+							// position rather than replaying from the startup cursor.
+							client.UpdateCursor(pendingCursor)
 							// Log summary of batches processed since last log
 							if pendingBatchCount > 0 {
 								freshnessSeconds := common.CalculateFreshness(pendingCursor)

--- a/ingest/internal/jetstream_ingest/client.go
+++ b/ingest/internal/jetstream_ingest/client.go
@@ -33,6 +33,8 @@ func NewClient(url string, logger *common.IngestLogger) *Client {
 
 // SetCursor sets the cursor for rewinding to a specific timestamp
 func (c *Client) SetCursor(timeUs int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.cursor = &timeUs
 }
 
@@ -40,10 +42,15 @@ func (c *Client) SetCursor(timeUs int64) {
 func (c *Client) Connect(ctx context.Context) error {
 	url := c.url
 
+	// Read cursor under lock since it may be updated by UpdateCursor
+	c.mu.RLock()
+	cursor := c.cursor
+	c.mu.RUnlock()
+
 	// Add cursor parameter if set
-	if c.cursor != nil {
-		url = fmt.Sprintf("%s?cursor=%d", c.url, *c.cursor)
-		c.logger.Info("Connecting to Jetstream at %s with cursor (rewinding to timestamp %d)", c.url, *c.cursor)
+	if cursor != nil {
+		url = fmt.Sprintf("%s?cursor=%d", c.url, *cursor)
+		c.logger.Info("Connecting to Jetstream at %s with cursor (rewinding to timestamp %d)", c.url, *cursor)
 	} else {
 		c.logger.Info("Connecting to Jetstream at %s", c.url)
 	}
@@ -188,6 +195,15 @@ func (c *Client) readLoop(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// UpdateCursor updates the cursor used for reconnections to the latest processed timestamp.
+// This should be called periodically as messages are processed to avoid replaying
+// stale data on WebSocket reconnection.
+func (c *Client) UpdateCursor(timeUs int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cursor = &timeUs
 }
 
 // GetMessageChannel returns the channel that receives raw JSON messages


### PR DESCRIPTION
Fixes #281

The Jetstream cursor was not updated. Whenever the websocket connection dropped (which is relatively often), we would rewind to the cursor that was stored on startup. Because staging deployments happen more often, the staging cursor would tend to be more recent, which explains the radically different behavior between stage/prod.

This PR keeps the cursor up-to-date, so we don't rewind more than a few seconds after losing the websocket connection. Should also reduce ES resource usage.