### PR TITLE
Enable cost allocation when spinning up a new gke cluster

### DIFF
--- a/index/deploy.sh
+++ b/index/deploy.sh
@@ -226,7 +226,8 @@ setup_kubectl_context() {
                     --project="$GE_GCP_PROJECT_ID" \
                     --release-channel=regular \
                     --enable-private-nodes \
-                    --master-ipv4-cidr="$cluster_cidr"
+                    --master-ipv4-cidr="$cluster_cidr" \
+                    --enable-cost-allocation
                 log_success "Cluster created successfully"
             else
                 log_error "GKE cluster $GE_K8S_CLUSTER does not exist in project $GE_GCP_PROJECT_ID"


### PR DESCRIPTION
Small change to turn on cost allocation so we can see where we're spending money inside GKE.

It has also been enabled on existing clusters.