### PR TITLE
Reduce prod ES node CPU requests/double memory

### DIFF
--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -59,14 +59,14 @@ patches:
               - name: elasticsearch
                 resources:
                   requests:
-                    memory: 16Gi
+                    memory: 32Gi
                     cpu: "7200m"
                   limits:
-                    memory: 16Gi
+                    memory: 32Gi
                     cpu: "7200m"
                 env:
                 - name: ES_JAVA_OPTS
-                  value: "-Xms8g -Xmx8g"
+                  value: "-Xms16g -Xmx16g"
           volumeClaimTemplates:
           - metadata:
               name: elasticsearch-data


### PR DESCRIPTION
Part of #284, part of #295

Reduces CPU requests/limits for production Elasticsearch nodes by approximately 10% to lower resource consumption. We'll reduce further if this goes well.

Should be fine given CPU utilization has dropped to below 20% since bugfix last week:

<img width="927" height="335" alt="Screenshot 2026-03-15 at 8 56 08 PM" src="https://github.com/user-attachments/assets/0c14c354-3b5f-41d6-a85a-9a978c93a093" />


# This PR

- Reduce master node CPU
- Reduce data node CPU

# Testing

- Deploy prod ES: `index/deploy.sh prod --ctypes resource`