### PR TITLE
Reduce prod data node CPU to 3000m

### DIFF
--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -61,10 +61,10 @@ patches:
                 resources:
                   requests:
                     memory: 32Gi
-                    cpu: "3600m"
+                    cpu: "3000m"
                   limits:
                     memory: 32Gi
-                    cpu: "3600m"
+                    cpu: "3000m"
                 env:
                 - name: ES_JAVA_OPTS
                   value: "-Xms16g -Xmx16g"


### PR DESCRIPTION
Part of https://github.com/greenearth-social/ingex/issues/284

# This PR

- Reduce prod Elasticsearch data node CPU requests/limits from 3600m to 3000m

# Testing

- Deploy prod ES: `index/deploy.sh prod --ctypes resource`