### PR TITLE
Instrument the extract and expiry services

### DIFF
--- a/ingest/cmd/elasticsearch_expiry/main.go
+++ b/ingest/cmd/elasticsearch_expiry/main.go
@@ -102,6 +102,7 @@ func main() {
 
 func runExpiry(ctx context.Context, config *common.Config, logger *common.IngestLogger, healthServer *common.HealthServer, dryRun, skipTLSVerify bool, retentionHours, hashtagRetentionHours int) error {
 	runStart := time.Now()
+	logger.Metric("expiry.run_attempted_count", 1)
 	// Default graceful timeout for delete operations during shutdown
 	const graceTimeout = 30 * time.Second
 	// Initialize Elasticsearch client

--- a/ingest/cmd/elasticsearch_expiry/main.go
+++ b/ingest/cmd/elasticsearch_expiry/main.go
@@ -26,6 +26,17 @@ func main() {
 	config := common.LoadConfig()
 	logger := common.NewLogger(config.LoggingEnabled)
 	logger.SetDebugEnabled(*debug)
+	otelCollector, err := common.NewOTelMetricCollector("elasticsearch-expiry", config.Environment, config.GCPProjectID, config.GCPRegion, config.MetricExportIntervalSec)
+	if err != nil {
+		logger.Error("Failed to create OTel metric collector: %v (continuing without metrics)", err)
+	} else {
+		logger.SetMetricCollector(otelCollector)
+		defer func() {
+			if err := otelCollector.Shutdown(context.Background()); err != nil {
+				logger.Error("Failed to shutdown OTel metric collector: %v", err)
+			}
+		}()
+	}
 
 	logger.Info("Green Earth Ingex - Elasticsearch Expiry Service")
 	logger.Info("Retention period: %d hours (%.1f days)", *retentionHours, float64(*retentionHours)/24.0)
@@ -82,6 +93,7 @@ func main() {
 	// Run the expiry process
 	if err := runExpiry(ctx, config, logger, healthServer, *dryRun, *skipTLSVerify, *retentionHours, *hashtagRetentionHours); err != nil {
 		logger.Error("Expiry process failed: %v", err)
+		logger.Metric("expiry.run_error_count", 1)
 		os.Exit(1)
 	}
 
@@ -89,6 +101,7 @@ func main() {
 }
 
 func runExpiry(ctx context.Context, config *common.Config, logger *common.IngestLogger, healthServer *common.HealthServer, dryRun, skipTLSVerify bool, retentionHours, hashtagRetentionHours int) error {
+	runStart := time.Now()
 	// Default graceful timeout for delete operations during shutdown
 	const graceTimeout = 30 * time.Second
 	// Initialize Elasticsearch client
@@ -175,14 +188,18 @@ func runExpiry(ctx context.Context, config *common.Config, logger *common.Ingest
 		}()
 
 		logger.Info("Processing collection: %s (date field: %s)", collection.IndexAlias, collection.DateField)
+		logger.Metric("expiry.collection_attempted_count", 1)
 
 		deletedCount, err := expiryService.ExpireCollection(deleteCtx, collection)
 		deleteCancel() // Clean up the context
 
 		if err != nil {
+			logger.Metric("expiry.collection_error_count", 1)
 			return fmt.Errorf("failed to expire collection %s: %w", collection.IndexAlias, err)
 		}
 
+		logger.Metric("expiry.collection_success_count", 1)
+		logger.Metric("expiry.deleted_count", float64(deletedCount))
 		totalDeleted += deletedCount
 		logger.Info("Processed %s: %d documents %s", collection.IndexAlias, deletedCount,
 			func() string {
@@ -213,6 +230,7 @@ func runExpiry(ctx context.Context, config *common.Config, logger *common.Ingest
 	}()
 
 	logger.Info("Processing collection: hashtags (date field: hour)")
+	logger.Metric("expiry.collection_attempted_count", 1)
 	// Create a separate expiry service instance for hashtags with different cutoff
 	hashtagExpiryConfig := elasticsearch_expiry.Config{
 		CutoffDate: hashtagCutoffDate,
@@ -226,9 +244,12 @@ func runExpiry(ctx context.Context, config *common.Config, logger *common.Ingest
 	deleteCancel()
 
 	if err != nil {
+		logger.Metric("expiry.collection_error_count", 1)
 		return fmt.Errorf("failed to expire hashtags collection: %w", err)
 	}
 
+	logger.Metric("expiry.collection_success_count", 1)
+	logger.Metric("expiry.deleted_count", float64(deletedCount))
 	totalDeleted += deletedCount
 	logger.Info("Processed hashtags: %d documents %s", deletedCount,
 		func() string {
@@ -244,5 +265,7 @@ func runExpiry(ctx context.Context, config *common.Config, logger *common.Ingest
 	}
 	logger.Info("Expiry complete: %d total documents %s across all collections", totalDeleted, action)
 
+	logger.Metric("expiry.run_duration_ms", float64(time.Since(runStart).Milliseconds()))
+	logger.Metric("expiry.run_success_count", 1)
 	return nil
 }

--- a/ingest/cmd/extract/main.go
+++ b/ingest/cmd/extract/main.go
@@ -188,7 +188,6 @@ func runExport(ctx context.Context, config *common.Config, logger *common.Ingest
 		return fmt.Errorf("failed to create ES client: %w", err)
 	}
 
-	var failedIndices []string
 	for _, indexName := range indices {
 		logger.Info("Starting export from index: %s", indexName)
 		logger.Metric("extract.index_attempted_count", 1)
@@ -213,19 +212,16 @@ func runExport(ctx context.Context, config *common.Config, logger *common.Ingest
 		case IndexTypeUnknown:
 			logger.Error("Skipping index %s: unknown index type", indexName)
 			logger.Metric("extract.index_error_count", 1)
-			failedIndices = append(failedIndices, indexName)
 			continue
 		default:
 			logger.Error("Unhandled index type for index %s", indexName)
 			logger.Metric("extract.index_error_count", 1)
-			failedIndices = append(failedIndices, indexName)
 			continue
 		}
 
 		if exportErr != nil {
 			logger.Error("Failed to export index %s: %v", indexName, exportErr)
 			logger.Metric("extract.index_error_count", 1)
-			failedIndices = append(failedIndices, indexName)
 			continue
 		}
 
@@ -234,11 +230,6 @@ func runExport(ctx context.Context, config *common.Config, logger *common.Ingest
 	}
 
 	logger.Metric("extract.run_duration_ms", float64(time.Since(runStart).Milliseconds()))
-
-	if len(failedIndices) > 0 {
-		return fmt.Errorf("%d index(es) failed to export: %s", len(failedIndices), strings.Join(failedIndices, ", "))
-	}
-
 	logger.Metric("extract.run_success_count", 1)
 	return nil
 }

--- a/ingest/cmd/extract/main.go
+++ b/ingest/cmd/extract/main.go
@@ -29,6 +29,17 @@ func main() {
 
 	config := common.LoadConfig()
 	logger := common.NewLogger(config.LoggingEnabled)
+	otelCollector, err := common.NewOTelMetricCollector("extract", config.Environment, config.GCPProjectID, config.GCPRegion, config.MetricExportIntervalSec)
+	if err != nil {
+		logger.Error("Failed to create OTel metric collector: %v (continuing without metrics)", err)
+	} else {
+		logger.SetMetricCollector(otelCollector)
+		defer func() {
+			if err := otelCollector.Shutdown(context.Background()); err != nil {
+				logger.Error("Failed to shutdown OTel metric collector: %v", err)
+			}
+		}()
+	}
 
 	logger.Info("Green Earth Ingex - Elasticsearch Export Service")
 	if *dryRun {
@@ -99,6 +110,7 @@ func main() {
 	logger.Info("Starting export from %d index(es): %s", len(indices), strings.Join(indices, ", "))
 	if err := runExport(ctx, config, logger, *dryRun, *skipTLSVerify, *outputPath, indices, *startTime, *endTime, *skipInferences); err != nil {
 		logger.Error("Export failed: %v", err)
+		logger.Metric("extract.run_error_count", 1)
 		os.Exit(1)
 	}
 
@@ -107,6 +119,7 @@ func main() {
 
 func runExport(ctx context.Context, config *common.Config, logger *common.IngestLogger,
 	dryRun, skipTLSVerify bool, outputPath string, indices []string, startTime, endTime string, skipInferences bool) error {
+	runStart := time.Now()
 
 	if config.ElasticsearchURL == "" {
 		return fmt.Errorf("GE_ELASTICSEARCH_URL environment variable is required")
@@ -175,8 +188,10 @@ func runExport(ctx context.Context, config *common.Config, logger *common.Ingest
 		return fmt.Errorf("failed to create ES client: %w", err)
 	}
 
+	var failedIndices []string
 	for _, indexName := range indices {
 		logger.Info("Starting export from index: %s", indexName)
+		logger.Metric("extract.index_attempted_count", 1)
 
 		indexType := getIndexType(indexName, logger)
 
@@ -188,6 +203,7 @@ func runExport(ctx context.Context, config *common.Config, logger *common.Ingest
 			if exportErr == nil && !skipInferences && len(atURIs) > 0 {
 				if infErr := runExportForPostInferences(ctx, esClient, logger, dryRun, outputPath, isGCS, gcsClient, gcsBucket, gcsPrefix, atURIs, config); infErr != nil {
 					logger.Error("Failed to export inferences for posts: %v", infErr)
+					logger.Metric("extract.inference_error_count", 1)
 				}
 			}
 		case IndexTypeLikes:
@@ -196,20 +212,34 @@ func runExport(ctx context.Context, config *common.Config, logger *common.Ingest
 			exportErr = runExportForHashtags(ctx, esClient, logger, dryRun, outputPath, isGCS, gcsClient, gcsBucket, gcsPrefix, indexName, startTime, endTime, config)
 		case IndexTypeUnknown:
 			logger.Error("Skipping index %s: unknown index type", indexName)
+			logger.Metric("extract.index_error_count", 1)
+			failedIndices = append(failedIndices, indexName)
 			continue
 		default:
 			logger.Error("Unhandled index type for index %s", indexName)
+			logger.Metric("extract.index_error_count", 1)
+			failedIndices = append(failedIndices, indexName)
 			continue
 		}
 
 		if exportErr != nil {
 			logger.Error("Failed to export index %s: %v", indexName, exportErr)
+			logger.Metric("extract.index_error_count", 1)
+			failedIndices = append(failedIndices, indexName)
 			continue
 		}
 
+		logger.Metric("extract.index_success_count", 1)
 		logger.Info("Completed export from index: %s", indexName)
 	}
 
+	logger.Metric("extract.run_duration_ms", float64(time.Since(runStart).Milliseconds()))
+
+	if len(failedIndices) > 0 {
+		return fmt.Errorf("%d index(es) failed to export: %s", len(failedIndices), strings.Join(failedIndices, ", "))
+	}
+
+	logger.Metric("extract.run_success_count", 1)
 	return nil
 }
 
@@ -289,6 +319,8 @@ func runExportForPosts(ctx context.Context, esClient *elasticsearch.Client, logg
 		}
 	}
 
+	logger.Metric("extract.records_exported_count", float64(totalRecords))
+	logger.Metric("extract.files_written_count", float64(fileNum))
 	logger.Info("Export complete: %d total records in %d files", totalRecords, fileNum)
 	return allAtURIs, nil
 }
@@ -364,6 +396,8 @@ func runExportForLikes(ctx context.Context, esClient *elasticsearch.Client, logg
 		}
 	}
 
+	logger.Metric("extract.records_exported_count", float64(totalRecords))
+	logger.Metric("extract.files_written_count", float64(fileNum))
 	logger.Info("Export complete: %d total records in %d files", totalRecords, fileNum)
 	return nil
 }
@@ -438,6 +472,8 @@ func runExportForHashtags(ctx context.Context, esClient *elasticsearch.Client, l
 		}
 	}
 
+	logger.Metric("extract.records_exported_count", float64(totalRecords))
+	logger.Metric("extract.files_written_count", float64(fileNum))
 	logger.Info("Export complete: %d total records in %d files", totalRecords, fileNum)
 	return nil
 }
@@ -687,6 +723,7 @@ func runExportForPostInferences(ctx context.Context, esClient *elasticsearch.Cli
 		logger.Debug("Dry-run: Would write %s with %d records", filename, len(allInferences))
 	}
 
+	logger.Metric("extract.records_exported_count", float64(len(allInferences)))
 	logger.Info("Inference export complete: %d records", len(allInferences))
 	return nil
 }

--- a/ingest/cmd/extract/main.go
+++ b/ingest/cmd/extract/main.go
@@ -120,6 +120,7 @@ func main() {
 func runExport(ctx context.Context, config *common.Config, logger *common.IngestLogger,
 	dryRun, skipTLSVerify bool, outputPath string, indices []string, startTime, endTime string, skipInferences bool) error {
 	runStart := time.Now()
+	logger.Metric("extract.run_attempted_count", 1)
 
 	if config.ElasticsearchURL == "" {
 		return fmt.Errorf("GE_ELASTICSEARCH_URL environment variable is required")

--- a/ingest/internal/elasticsearch_expiry/service.go
+++ b/ingest/internal/elasticsearch_expiry/service.go
@@ -174,10 +174,12 @@ func (s *Service) deleteExpiredDocuments(ctx context.Context, collection Collect
 
 	if response.TimedOut {
 		s.logger.Error("Delete by query timed out for %s", collection.IndexAlias)
+		s.logger.Metric("expiry.timed_out_count", 1)
 	}
 
 	if len(response.Failures) > 0 {
 		s.logger.Error("Delete by query had %d failures for %s", len(response.Failures), collection.IndexAlias)
+		s.logger.Metric("expiry.bulk_failures_count", float64(len(response.Failures)))
 		for i, failure := range response.Failures {
 			s.logger.Error("Failure %d: %v", i+1, failure)
 		}


### PR DESCRIPTION
The `extract` and `elasticsearch_expiry` services previously only emitted
structured log lines on errors, with no metrics. This meant that partial
failures — such as a parquet export succeeding for `posts` but silently
failing for `likes` or `hashtags` — were invisible to alerting.

### Changes

**Both services** now initialize the existing OTel metric collector
(`NewOTelMetricCollector`) on startup, following the same pattern as
`jetstream_ingest`. Metrics are exported to GCP Cloud Monitoring under
`custom.googleapis.com/ingex/` when `GE_GCP_PROJECT_ID` is set, or
printed to stdout in local development.

**`extract`** now tracks:
- `extract.index_attempted_count` / `extract.index_success_count` / `extract.index_error_count` — per-index export outcomes (enables failure rate alerting)
- `extract.inference_error_count` — inference export failures
- `extract.records_exported_count` / `extract.files_written_count` — throughput/capacity planning
- `extract.run_duration_ms` — end-to-end run duration
- `extract.run_error_count` / `extract.run_success_count` — overall run outcome

**`elasticsearch_expiry`** now tracks:
- `expiry.collection_attempted_count` / `expiry.collection_success_count` / `expiry.collection_error_count` — per-collection outcomes
- `expiry.deleted_count` — documents deleted per collection
- `expiry.timed_out_count` — delete-by-query timeouts
- `expiry.bulk_failures_count` — individual bulk failure count from Elasticsearch
- `expiry.run_duration_ms` — end-to-end run duration
- `expiry.run_error_count` / `expiry.run_success_count` — overall run outcome