### PR TITLE
Failure metrics for ingest services

### DIFF
--- a/ingest/cmd/jetstream_ingest/main.go
+++ b/ingest/cmd/jetstream_ingest/main.go
@@ -203,6 +203,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 						wc := gcsClient.Bucket(blocklistBucket).Object(objectPath).NewWriter(ctx)
 						if _, werr := wc.Write(data); werr != nil {
 							logger.Error("Failed to write blocklist to GCS: %v", werr)
+							logger.Metric("jetstream.blocklist_export_error_count", 1)
 							if cerr := wc.Close(); cerr != nil {
 								logger.Error("Failed to close GCS writer after write error: %v", cerr)
 							}
@@ -211,6 +212,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 						}
 						if werr := wc.Close(); werr != nil {
 							logger.Error("Failed to close GCS writer for blocklist: %v", werr)
+							logger.Metric("jetstream.blocklist_export_error_count", 1)
 							historyMu.Unlock()
 							continue
 						}
@@ -289,6 +291,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 					if hasPendingUpdate {
 						if err := stateManager.UpdateCursor(pendingCursor); err != nil {
 							logger.Error("Failed to flush final cursor update: %v", err)
+							logger.Metric("jetstream.state_update_error_count", 1)
 						}
 						client.UpdateCursor(pendingCursor)
 					}
@@ -299,6 +302,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 					if hasPendingUpdate {
 						if err := stateManager.UpdateCursor(pendingCursor); err != nil {
 							logger.Error("Failed to update cursor: %v", err)
+							logger.Metric("jetstream.state_update_error_count", 1)
 						} else {
 							hasPendingUpdate = false
 							// Keep the client's reconnection cursor in sync so that
@@ -359,6 +363,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 			if msg.IsLikeDelete() {
 				if msg.GetAtURI() == "" {
 					logger.Error("Skipping like deletion with empty at_uri (author_did: %s)", msg.GetAuthorDID())
+					logger.Metric("jetstream.validation_skip_count", 1)
 					skippedCount++
 					continue
 				}
@@ -447,12 +452,14 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 
 				if msg.GetAtURI() == "" {
 					logger.Error("Skipping like with empty at_uri (author_did: %s)", msg.GetAuthorDID())
+					logger.Metric("jetstream.validation_skip_count", 1)
 					skippedCount++
 					continue
 				}
 
 				if msg.GetSubjectURI() == "" {
 					logger.Error("Skipping like with empty subject_uri (at_uri: %s, author_did: %s)", msg.GetAtURI(), msg.GetAuthorDID())
+					logger.Metric("jetstream.validation_skip_count", 1)
 					skippedCount++
 					continue
 				}

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -264,6 +264,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 			// Skip rows with empty at_uri unless it's an account deletion event
 			if row.AtURI == "" && !msg.IsAccountDeletion() {
 				logger.Debug("Skipping row with empty at_uri from file %s (did: %s)", row.SourceFilename, row.DID)
+				logger.Metric("megastream.row_skip_count", 1)
 				skippedCount++
 				continue
 			}
@@ -342,6 +343,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				// Now process account deletion
 				if err := handleAccountDeletion(ctx, msg, esClient, dryRun, logger, &deletedCount); err != nil {
 					logger.Error("Failed to handle account deletion for DID %s: %v", msg.GetAuthorDID(), err)
+					logger.Metric("megastream.account_deletion_error_count", 1)
 				}
 			} else if msg.IsDelete() {
 				// Post deletion - add to batch

--- a/ingest/internal/common/elasticsearch.go
+++ b/ingest/internal/common/elasticsearch.go
@@ -50,16 +50,16 @@ type ExternalEmbed struct {
 
 // ElasticsearchDoc represents the document structure for indexing
 type ElasticsearchDoc struct {
-	AtURI            string                  `json:"at_uri"`
-	AuthorDID        string                  `json:"author_did"`
-	Content          string                  `json:"content"`
-	CreatedAt        string                  `json:"created_at"`
-	ThreadRootPost   string                  `json:"thread_root_post,omitempty"`
-	ThreadParentPost string                  `json:"thread_parent_post,omitempty"`
-	QuotePost        string                  `json:"quote_post,omitempty"`
-	Embeddings       map[string]Float32Array `json:"embeddings,omitempty"`
-	IndexedAt        string                  `json:"indexed_at"`
-	LikeCount        int                     `json:"like_count"`
+	AtURI                   string                  `json:"at_uri"`
+	AuthorDID               string                  `json:"author_did"`
+	Content                 string                  `json:"content"`
+	CreatedAt               string                  `json:"created_at"`
+	ThreadRootPost          string                  `json:"thread_root_post,omitempty"`
+	ThreadParentPost        string                  `json:"thread_parent_post,omitempty"`
+	QuotePost               string                  `json:"quote_post,omitempty"`
+	Embeddings              map[string]Float32Array `json:"embeddings,omitempty"`
+	IndexedAt               string                  `json:"indexed_at"`
+	LikeCount               int                     `json:"like_count"`
 	Media                   []MediaItem             `json:"media,omitempty"`
 	ContainsImages          bool                    `json:"contains_images"`
 	ContainsVideo           bool                    `json:"contains_video"`
@@ -1130,7 +1130,6 @@ func FetchLikes(ctx context.Context, client *elasticsearch.Client, logger *Inges
 
 	return response, nil
 }
-
 
 // QueryPostsByAuthorDID retrieves all post at_uris for a given author_did using scroll API
 func QueryPostsByAuthorDID(ctx context.Context, client *elasticsearch.Client, index string, authorDID string, logger *IngestLogger) ([]string, error) {

--- a/ingest/internal/common/elasticsearch.go
+++ b/ingest/internal/common/elasticsearch.go
@@ -215,6 +215,7 @@ func BulkIndex(ctx context.Context, client *elasticsearch.Client, index string, 
 	)
 	logger.Metric("es.bulk_index_posts.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
+		logger.Metric("es.bulk_index_posts.error_count", 1)
 		return fmt.Errorf("bulk request failed: %w", err)
 	}
 	defer func() {
@@ -224,6 +225,7 @@ func BulkIndex(ctx context.Context, client *elasticsearch.Client, index string, 
 	}()
 
 	if res.IsError() {
+		logger.Metric("es.bulk_index_posts.error_count", 1)
 		return fmt.Errorf("bulk request returned error: %s", res.String())
 	}
 
@@ -247,6 +249,7 @@ func BulkIndex(ctx context.Context, client *elasticsearch.Client, index string, 
 	if bulkResponse.Errors {
 		itemsJSON, _ := json.Marshal(bulkResponse.Items)
 		logger.Error("Bulk indexing failed with errors. Response items: %s", string(itemsJSON))
+		logger.Metric("es.bulk_index_posts.error_count", 1)
 		return fmt.Errorf("bulk indexing failed: some documents had errors (see logs for details)")
 	}
 
@@ -312,6 +315,7 @@ func BulkIndexPostTombstones(ctx context.Context, client *elasticsearch.Client, 
 	)
 	logger.Metric("es.bulk_index_tombstones.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
+		logger.Metric("es.bulk_index_tombstones.error_count", 1)
 		return fmt.Errorf("bulk tombstone request failed: %w", err)
 	}
 	defer func() {
@@ -321,6 +325,7 @@ func BulkIndexPostTombstones(ctx context.Context, client *elasticsearch.Client, 
 	}()
 
 	if res.IsError() {
+		logger.Metric("es.bulk_index_tombstones.error_count", 1)
 		return fmt.Errorf("bulk tombstone request returned error: %s", res.String())
 	}
 
@@ -344,6 +349,7 @@ func BulkIndexPostTombstones(ctx context.Context, client *elasticsearch.Client, 
 	if bulkResponse.Errors {
 		itemsJSON, _ := json.Marshal(bulkResponse.Items)
 		logger.Error("Bulk tombstone indexing failed with errors. Response items: %s", string(itemsJSON))
+		logger.Metric("es.bulk_index_tombstones.error_count", 1)
 		return fmt.Errorf("bulk tombstone indexing failed: some documents had errors (see logs for details)")
 	}
 
@@ -401,6 +407,7 @@ func BulkDelete(ctx context.Context, client *elasticsearch.Client, index string,
 	)
 	logger.Metric("es.bulk_delete.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
+		logger.Metric("es.bulk_delete.error_count", 1)
 		return fmt.Errorf("bulk delete request failed: %w", err)
 	}
 	defer func() {
@@ -410,6 +417,7 @@ func BulkDelete(ctx context.Context, client *elasticsearch.Client, index string,
 	}()
 
 	if res.IsError() {
+		logger.Metric("es.bulk_delete.error_count", 1)
 		return fmt.Errorf("bulk delete request returned error: %s", res.String())
 	}
 
@@ -445,6 +453,7 @@ func BulkDelete(ctx context.Context, client *elasticsearch.Client, index string,
 		if hasRealErrors {
 			itemsJSON, _ := json.Marshal(bulkResponse.Items)
 			logger.Error("Bulk delete failed with errors. Response items: %s", string(itemsJSON))
+			logger.Metric("es.bulk_delete.error_count", 1)
 			return fmt.Errorf("bulk delete failed: some documents had errors (see logs for details)")
 		}
 	}
@@ -607,6 +616,7 @@ func BulkIndexLikes(ctx context.Context, client *elasticsearch.Client, index str
 	)
 	logger.Metric("es.bulk_index_likes.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
+		logger.Metric("es.bulk_index_likes.error_count", 1)
 		return fmt.Errorf("bulk like request failed: %w", err)
 	}
 	defer func() {
@@ -616,6 +626,7 @@ func BulkIndexLikes(ctx context.Context, client *elasticsearch.Client, index str
 	}()
 
 	if res.IsError() {
+		logger.Metric("es.bulk_index_likes.error_count", 1)
 		return fmt.Errorf("bulk like request returned error: %s", res.String())
 	}
 
@@ -639,6 +650,7 @@ func BulkIndexLikes(ctx context.Context, client *elasticsearch.Client, index str
 	if bulkResponse.Errors {
 		itemsJSON, _ := json.Marshal(bulkResponse.Items)
 		logger.Error("Bulk like indexing failed with errors. Response items: %s", string(itemsJSON))
+		logger.Metric("es.bulk_index_likes.error_count", 1)
 		return fmt.Errorf("bulk like indexing failed: some documents had errors (see logs for details)")
 	}
 
@@ -689,6 +701,7 @@ func BulkGetLikes(ctx context.Context, client *elasticsearch.Client, index strin
 	)
 	logger.Metric("es.bulk_get_likes.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
+		logger.Metric("es.bulk_get_likes.error_count", 1)
 		return nil, fmt.Errorf("mget request failed: %w", err)
 	}
 	defer func() {
@@ -698,6 +711,7 @@ func BulkGetLikes(ctx context.Context, client *elasticsearch.Client, index strin
 	}()
 
 	if res.IsError() {
+		logger.Metric("es.bulk_get_likes.error_count", 1)
 		return nil, fmt.Errorf("mget request returned error: %s", res.String())
 	}
 
@@ -791,6 +805,7 @@ func BulkIndexLikeTombstones(ctx context.Context, client *elasticsearch.Client, 
 	)
 	logger.Metric("es.bulk_index_like_tombstones.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
+		logger.Metric("es.bulk_index_like_tombstones.error_count", 1)
 		return fmt.Errorf("bulk like tombstone request failed: %w", err)
 	}
 	defer func() {
@@ -800,6 +815,7 @@ func BulkIndexLikeTombstones(ctx context.Context, client *elasticsearch.Client, 
 	}()
 
 	if res.IsError() {
+		logger.Metric("es.bulk_index_like_tombstones.error_count", 1)
 		return fmt.Errorf("bulk like tombstone request returned error: %s", res.String())
 	}
 
@@ -823,6 +839,7 @@ func BulkIndexLikeTombstones(ctx context.Context, client *elasticsearch.Client, 
 	if bulkResponse.Errors {
 		itemsJSON, _ := json.Marshal(bulkResponse.Items)
 		logger.Error("Bulk like tombstone indexing failed with errors. Response items: %s", string(itemsJSON))
+		logger.Metric("es.bulk_index_like_tombstones.error_count", 1)
 		return fmt.Errorf("bulk like tombstone indexing failed: some documents had errors (see logs for details)")
 	}
 
@@ -1502,6 +1519,7 @@ func BulkUpdatePostLikeCounts(ctx context.Context, client *elasticsearch.Client,
 	)
 	logger.Metric("es.update_like_counts.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
+		logger.Metric("es.update_like_counts.error_count", 1)
 		return fmt.Errorf("bulk update request failed: %w", err)
 	}
 	defer func() {
@@ -1511,6 +1529,7 @@ func BulkUpdatePostLikeCounts(ctx context.Context, client *elasticsearch.Client,
 	}()
 
 	if res.IsError() {
+		logger.Metric("es.update_like_counts.error_count", 1)
 		return fmt.Errorf("bulk update request returned error: %s", res.String())
 	}
 
@@ -1560,6 +1579,7 @@ func BulkUpdatePostLikeCounts(ctx context.Context, client *elasticsearch.Client,
 			itemsJSON, _ := json.Marshal(bulkResponse.Items)
 			logger.Error("Bulk like-count update failed with errors")
 			logger.Debug("Response items with errors: %s", string(itemsJSON))
+			logger.Metric("es.update_like_counts.error_count", 1)
 			return fmt.Errorf("bulk update failed: some updates had errors")
 		}
 	}
@@ -1723,6 +1743,7 @@ func BulkUpdateHashtagCounts(ctx context.Context, client *elasticsearch.Client, 
 	)
 	logger.Metric("es.update_hashtags.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
+		logger.Metric("es.update_hashtags.error_count", 1)
 		return fmt.Errorf("bulk request failed: %w", err)
 	}
 	defer func() {
@@ -1732,6 +1753,7 @@ func BulkUpdateHashtagCounts(ctx context.Context, client *elasticsearch.Client, 
 	}()
 
 	if res.IsError() {
+		logger.Metric("es.update_hashtags.error_count", 1)
 		return fmt.Errorf("bulk request returned error: %s", res.String())
 	}
 
@@ -1756,6 +1778,7 @@ func BulkUpdateHashtagCounts(ctx context.Context, client *elasticsearch.Client, 
 	if bulkResponse.Errors {
 		itemsJSON, _ := json.Marshal(bulkResponse.Items)
 		logger.Error("Bulk hashtag update failed with errors. Response items: %s", string(itemsJSON))
+		logger.Metric("es.update_hashtags.error_count", 1)
 		return fmt.Errorf("bulk hashtag update failed: some updates had errors (see logs for details)")
 	}
 
@@ -1828,6 +1851,7 @@ func BulkIndexInferences(ctx context.Context, client *elasticsearch.Client, inde
 	)
 	logger.Metric("es.bulk_index_inferences.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
+		logger.Metric("es.bulk_index_inferences.error_count", 1)
 		return fmt.Errorf("bulk inference request failed: %w", err)
 	}
 	defer func() {
@@ -1837,6 +1861,7 @@ func BulkIndexInferences(ctx context.Context, client *elasticsearch.Client, inde
 	}()
 
 	if res.IsError() {
+		logger.Metric("es.bulk_index_inferences.error_count", 1)
 		return fmt.Errorf("bulk inference request returned error: %s", res.String())
 	}
 
@@ -1860,6 +1885,7 @@ func BulkIndexInferences(ctx context.Context, client *elasticsearch.Client, inde
 	if bulkResponse.Errors {
 		itemsJSON, _ := json.Marshal(bulkResponse.Items)
 		logger.Error("Bulk inference indexing failed with errors. Response items: %s", string(itemsJSON))
+		logger.Metric("es.bulk_index_inferences.error_count", 1)
 		return fmt.Errorf("bulk inference indexing failed: some documents had errors (see logs for details)")
 	}
 

--- a/ingest/internal/common/otel_metrics.go
+++ b/ingest/internal/common/otel_metrics.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"fmt"
+
 	gcpmetric "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"

--- a/ingest/internal/common/otel_metrics.go
+++ b/ingest/internal/common/otel_metrics.go
@@ -8,6 +8,7 @@ import (
 
 	"fmt"
 	gcpmetric "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -19,12 +20,13 @@ import (
 
 // OTelMetricCollector exports metrics via OpenTelemetry to GCP Cloud Monitoring or stdout.
 type OTelMetricCollector struct {
-	meter      metric.Meter
-	provider   *sdkmetric.MeterProvider
-	mu         sync.RWMutex
-	histograms map[string]metric.Float64Histogram
-	gauges     map[string]metric.Float64Gauge
-	counters   map[string]metric.Int64Counter
+	meter       metric.Meter
+	provider    *sdkmetric.MeterProvider
+	serviceName string
+	mu          sync.RWMutex
+	histograms  map[string]metric.Float64Histogram
+	gauges      map[string]metric.Float64Gauge
+	counters    map[string]metric.Int64Counter
 }
 
 // NewOTelMetricCollector creates a new OTel-based metric collector.
@@ -75,11 +77,12 @@ func NewOTelMetricCollector(serviceName, env, projectID, region string, exportIn
 	meter := provider.Meter("greenearth/ingex")
 
 	return &OTelMetricCollector{
-		meter:      meter,
-		provider:   provider,
-		histograms: make(map[string]metric.Float64Histogram),
-		gauges:     make(map[string]metric.Float64Gauge),
-		counters:   make(map[string]metric.Int64Counter),
+		meter:       meter,
+		provider:    provider,
+		serviceName: serviceName,
+		histograms:  make(map[string]metric.Float64Histogram),
+		gauges:      make(map[string]metric.Float64Gauge),
+		counters:    make(map[string]metric.Int64Counter),
 	}, nil
 }
 
@@ -102,11 +105,12 @@ func newOTelMetricCollectorWithReader(reader sdkmetric.Reader, serviceName, env 
 	meter := provider.Meter("greenearth/ingex")
 
 	return &OTelMetricCollector{
-		meter:      meter,
-		provider:   provider,
-		histograms: make(map[string]metric.Float64Histogram),
-		gauges:     make(map[string]metric.Float64Gauge),
-		counters:   make(map[string]metric.Int64Counter),
+		meter:       meter,
+		provider:    provider,
+		serviceName: serviceName,
+		histograms:  make(map[string]metric.Float64Histogram),
+		gauges:      make(map[string]metric.Float64Gauge),
+		counters:    make(map[string]metric.Int64Counter),
 	}
 }
 
@@ -116,15 +120,16 @@ func newOTelMetricCollectorWithReader(reader sdkmetric.Reader, serviceName, env 
 // - All others → histogram
 //   - E.g., names ending in "_ms" or "_sec" → histogram
 func (c *OTelMetricCollector) Record(name string, value float64) {
+	serviceAttr := metric.WithAttributes(attribute.String("service", c.serviceName))
 	if isCounterMetric(name) {
 		counter := c.getOrCreateCounter(name)
-		counter.Add(context.Background(), int64(value))
+		counter.Add(context.Background(), int64(value), serviceAttr)
 	} else if isGaugeMetric(name) {
 		gauge := c.getOrCreateGauge(name)
-		gauge.Record(context.Background(), value)
+		gauge.Record(context.Background(), value, serviceAttr)
 	} else {
 		hist := c.getOrCreateHistogram(name)
-		hist.Record(context.Background(), value)
+		hist.Record(context.Background(), value, serviceAttr)
 	}
 }
 

--- a/ingest/internal/common/otel_metrics_test.go
+++ b/ingest/internal/common/otel_metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -200,4 +201,56 @@ func TestOTelMetricCollector_MultipleMetrics(t *testing.T) {
 	requireMetric(t, rm, "a.duration_ms")
 	requireMetric(t, rm, "b.hit_rate")
 	requireMetric(t, rm, "c.other")
+}
+
+func TestOTelMetricCollector_ServiceAttribute(t *testing.T) {
+	reader := metric.NewManualReader()
+	collector := newOTelMetricCollectorWithReader(reader, "my-test-service", "local")
+
+	collector.Record("test.error_count", 1.0)
+
+	rm := collectMetrics(t, reader)
+	m := requireMetric(t, rm, "test.error_count")
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("Expected Sum for _count metric, got %T", m.Data)
+	}
+	if len(sum.DataPoints) != 1 {
+		t.Fatalf("Expected 1 data point, got %d", len(sum.DataPoints))
+	}
+
+	dp := sum.DataPoints[0]
+	serviceAttr, found := dp.Attributes.Value(attribute.Key("service"))
+	if !found {
+		t.Fatal("Expected 'service' attribute on data point, but not found")
+	}
+	if serviceAttr.AsString() != "my-test-service" {
+		t.Errorf("Expected service attribute 'my-test-service', got %q", serviceAttr.AsString())
+	}
+}
+
+func TestOTelMetricCollector_ServiceAttributeOnHistogram(t *testing.T) {
+	reader := metric.NewManualReader()
+	collector := newOTelMetricCollectorWithReader(reader, "hist-service", "local")
+
+	collector.Record("es.bulk_index.duration_ms", 150.0)
+
+	rm := collectMetrics(t, reader)
+	m := requireMetric(t, rm, "es.bulk_index.duration_ms")
+	hist, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("Expected Histogram, got %T", m.Data)
+	}
+	if len(hist.DataPoints) != 1 {
+		t.Fatalf("Expected 1 data point, got %d", len(hist.DataPoints))
+	}
+
+	dp := hist.DataPoints[0]
+	serviceAttr, found := dp.Attributes.Value(attribute.Key("service"))
+	if !found {
+		t.Fatal("Expected 'service' attribute on data point, but not found")
+	}
+	if serviceAttr.AsString() != "hist-service" {
+		t.Errorf("Expected service attribute 'hist-service', got %q", serviceAttr.AsString())
+	}
 }

--- a/ingest/internal/jetstream_ingest/client.go
+++ b/ingest/internal/jetstream_ingest/client.go
@@ -147,6 +147,7 @@ func (c *Client) readLoop(ctx context.Context) {
 					c.mu.Unlock()
 					if shouldReconnect {
 						c.logger.Info("Reconnecting in 5 seconds...")
+						c.logger.Metric("jetstream.ws_reconnect_count", 1)
 						// Use a timer with context checking instead of blocking sleep
 						select {
 						case <-time.After(5 * time.Second):
@@ -170,6 +171,7 @@ func (c *Client) readLoop(ctx context.Context) {
 				c.mu.Unlock()
 				if shouldReconnect {
 					c.logger.Info("Reconnecting in 5 seconds...")
+					c.logger.Metric("jetstream.ws_reconnect_count", 1)
 					// Use a timer with context checking instead of blocking sleep
 					select {
 					case <-time.After(5 * time.Second):
@@ -189,6 +191,7 @@ func (c *Client) readLoop(ctx context.Context) {
 			case <-time.After(5 * time.Second):
 				// If we can't send within 5 seconds, log and drop
 				c.logger.Error("Message channel full for 5 seconds, dropping message")
+				c.logger.Metric("jetstream.dropped_messages_count", 1)
 			case <-ctx.Done():
 				// Context cancelled while trying to send
 				return

--- a/ingest/internal/megastream_ingest/spooler.go
+++ b/ingest/internal/megastream_ingest/spooler.go
@@ -128,6 +128,7 @@ func (ls *LocalSpooler) Start(ctx context.Context) error {
 			files, err := ls.discoverFiles()
 			if err != nil {
 				ls.logger.Error("Failed to discover files: %v", err)
+				ls.logger.Metric("megastream.file_discovery_error_count", 1)
 			} else {
 				ls.processFiles(ctx, files)
 			}
@@ -229,6 +230,7 @@ func (ls *LocalSpooler) processFiles(ctx context.Context, files []string) {
 
 		if err := ls.processFile(ctx, filePath, filename); err != nil {
 			ls.logger.Error("Failed to process file %s: %v", filename, err)
+			ls.logger.Metric("megastream.file_error_count", 1)
 		} else {
 			fileTimeUs, err := common.ParseMegastreamFilenameTimestamp(filename)
 			if err != nil {
@@ -238,6 +240,7 @@ func (ls *LocalSpooler) processFiles(ctx context.Context, files []string) {
 
 			if err := ls.stateManager.UpdateCursor(fileTimeUs); err != nil {
 				ls.logger.Error("Failed to update cursor for file %s: %v", filename, err)
+				ls.logger.Metric("megastream.state_update_error_count", 1)
 			} else {
 				ls.logger.Debug("Updated cursor to %d after processing file: %s", fileTimeUs, filename)
 			}
@@ -295,6 +298,7 @@ func (ss *S3Spooler) Start(ctx context.Context) error {
 			files, err := ss.discoverFiles(ctx)
 			if err != nil {
 				ss.logger.Error("Failed to discover files: %v", err)
+				ss.logger.Metric("megastream.file_discovery_error_count", 1)
 			} else {
 				ss.processFiles(ctx, files)
 			}
@@ -429,6 +433,7 @@ func (ss *S3Spooler) processFiles(ctx context.Context, keys []string) {
 
 		if err := ss.processFile(ctx, key, filename); err != nil {
 			ss.logger.Error("Failed to process S3 file %s: %v", key, err)
+			ss.logger.Metric("megastream.file_error_count", 1)
 		} else {
 			fileTimeUs, err := common.ParseMegastreamFilenameTimestamp(filename)
 			if err != nil {
@@ -441,6 +446,7 @@ func (ss *S3Spooler) processFiles(ctx context.Context, keys []string) {
 			// https://github.com/greenearth-social/ingex/issues/44
 			if err := ss.stateManager.UpdateCursor(fileTimeUs); err != nil {
 				ss.logger.Error("Failed to update cursor for file %s: %v", filename, err)
+				ss.logger.Metric("megastream.state_update_error_count", 1)
 			} else {
 				ss.logger.Debug("Updated cursor to %d after processing file: %s", fileTimeUs, filename)
 			}
@@ -651,6 +657,7 @@ func processDatabase(ctx context.Context, dbPath, filename string, rowChan chan<
 		var atURI, did, rawPost, inferences string
 		if err := rows.Scan(&atURI, &did, &rawPost, &inferences); err != nil {
 			logger.Error("Failed to scan row from %s: %v", filename, err)
+			logger.Metric("megastream.row_skip_count", 1)
 			continue
 		}
 


### PR DESCRIPTION
## Add failure metrics to ingest services

Adds operational failure metrics across jetstream and megastream ingest services, instrumenting error paths that were previously only logged. All new metrics use the `_count` suffix (auto-detected as monotonic counters by the OTel naming convention) and are exported to GCP Cloud Monitoring via the existing OpenTelemetry pipeline.

### Service attribute on all metrics

`OTelMetricCollector.Record()` now attaches a `service` attribute to every metric data point, derived from the service name already passed to the collector's constructor. This means ES-level error metrics automatically carry the correct service label without needing to change function signatures or the `MetricCollector` interface.

### Elasticsearch error metrics (shared layer)

All 9 bulk ES operations in `elasticsearch.go` now emit `es.<operation>.error_count` at every post-HTTP-request error site (request failure, error response, bulk item errors). Since these functions receive a logger whose collector already knows the service name, the `service` attribute distinguishes which service triggered the error.

Operations covered: `bulk_index_posts`, `bulk_index_tombstones`, `bulk_delete`, `bulk_index_likes`, `bulk_get_likes`, `bulk_index_like_tombstones`, `update_like_counts`, `update_hashtags`, `bulk_index_inferences`.

### Jetstream metrics

- `jetstream.ws_reconnect_count` — WebSocket reconnection events (normal close + read errors)
- `jetstream.dropped_messages_count` — messages dropped due to full channel
- `jetstream.validation_skip_count` — messages skipped for missing at_uri/subject_uri
- `jetstream.state_update_error_count` — cursor persistence failures
- `jetstream.blocklist_export_error_count` — GCS blocklist write failures

### Megastream metrics

- `megastream.row_skip_count` — rows skipped for empty at_uri or scan errors
- `megastream.account_deletion_error_count` — account deletion handling failures
- `megastream.file_discovery_error_count` — file listing failures (local + S3)
- `megastream.file_error_count` — file processing failures (local + S3)
- `megastream.state_update_error_count` — cursor persistence failures