### PR TITLE
Block on ensureIndices at startup, exit if no write alias

### DIFF
--- a/ingest/cmd/elasticsearch_expiry/main.go
+++ b/ingest/cmd/elasticsearch_expiry/main.go
@@ -117,6 +117,18 @@ func runExpiry(ctx context.Context, config *common.Config, logger *common.Ingest
 		return fmt.Errorf("failed to create Elasticsearch client: %w", err)
 	}
 
+	// Ensure hashtags has a valid write index before running delete-by-query.
+	// This prevents alias write-target errors when an alias points to multiple
+	// indices without an is_write_index designation.
+	if !dryRun {
+		indexCtx, indexCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer indexCancel()
+		hashtagsIndexName := common.CurrentIndexName("hashtags", config.IndexPeriod)
+		if err := common.EnsureIndex(indexCtx, esClient, hashtagsIndexName, "hashtags", logger); err != nil {
+			return fmt.Errorf("failed to ensure index for hashtags: %w", err)
+		}
+	}
+
 	// Calculate the cutoff date using hours
 	cutoffDate := time.Now().UTC().Add(-time.Duration(retentionHours) * time.Hour)
 	logger.Info("Deleting documents older than: %s", cutoffDate.Format(time.RFC3339))

--- a/ingest/cmd/elasticsearch_expiry/main.go
+++ b/ingest/cmd/elasticsearch_expiry/main.go
@@ -117,18 +117,6 @@ func runExpiry(ctx context.Context, config *common.Config, logger *common.Ingest
 		return fmt.Errorf("failed to create Elasticsearch client: %w", err)
 	}
 
-	// Ensure hashtags has a valid write index before running delete-by-query.
-	// This prevents alias write-target errors when an alias points to multiple
-	// indices without an is_write_index designation.
-	if !dryRun {
-		indexCtx, indexCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer indexCancel()
-		hashtagsIndexName := common.CurrentIndexName("hashtags", config.IndexPeriod)
-		if err := common.EnsureIndex(indexCtx, esClient, hashtagsIndexName, "hashtags", logger); err != nil {
-			return fmt.Errorf("failed to ensure index for hashtags: %w", err)
-		}
-	}
-
 	// Calculate the cutoff date using hours
 	cutoffDate := time.Now().UTC().Add(-time.Duration(retentionHours) * time.Hour)
 	logger.Info("Deleting documents older than: %s", cutoffDate.Format(time.RFC3339))

--- a/ingest/cmd/jetstream_ingest/main.go
+++ b/ingest/cmd/jetstream_ingest/main.go
@@ -138,22 +138,30 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 		os.Exit(1)
 	}
 
-	// Ensure period-based indices exist and are the write target for likes and
-	// like_tombstones. Runs at startup and every minute so that period rollovers
+	// Ensure period-based indices exist and are the write target for likes,
+	// like_tombstones, and posts. Jetstream updates post like counts through the
+	// posts alias, so posts must always have a write index as well. Runs at
+	// startup and every minute so that period rollovers
 	// are detected promptly without waiting for the next batch flush.
 	if !dryRun {
-		go func() {
-			ensureIndices := func() {
-				indexCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-				defer cancel()
-				for _, alias := range []string{"likes", "like_tombstones"} {
-					name := common.CurrentIndexName(alias, config.IndexPeriod)
-					if err := common.EnsureIndex(indexCtx, esClient, name, alias, logger); err != nil {
-						logger.Error("Failed to ensure index for %s: %v", alias, err)
-					}
+		ensureIndices := func() error {
+			indexCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			for _, alias := range []string{"likes", "like_tombstones", "posts"} {
+				name := common.CurrentIndexName(alias, config.IndexPeriod)
+				if err := common.EnsureIndex(indexCtx, esClient, name, alias, logger); err != nil {
+					return fmt.Errorf("failed to ensure index for %s: %w", alias, err)
 				}
 			}
-			ensureIndices()
+			return nil
+		}
+
+		if err := ensureIndices(); err != nil {
+			logger.Error("%v", err)
+			os.Exit(1)
+		}
+
+		go func() {
 			ticker := time.NewTicker(time.Minute)
 			defer ticker.Stop()
 			for {
@@ -161,7 +169,9 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					ensureIndices()
+					if err := ensureIndices(); err != nil {
+						logger.Error("%v", err)
+					}
 				}
 			}
 		}()

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -217,18 +217,23 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 	// post_tombstones. Runs at startup and every minute so that period rollovers
 	// are detected promptly without waiting for the next batch flush.
 	if !dryRun {
-		go func() {
-			ensureIndices := func() {
-				indexCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-				defer cancel()
-				for _, alias := range []string{"posts", "post_tombstones"} {
-					name := common.CurrentIndexName(alias, config.IndexPeriod)
-					if err := common.EnsureIndex(indexCtx, esClient, name, alias, logger); err != nil {
-						logger.Error("Failed to ensure index for %s: %v", alias, err)
-					}
+		ensureIndices := func() error {
+			indexCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			for _, alias := range []string{"posts", "post_tombstones"} {
+				name := common.CurrentIndexName(alias, config.IndexPeriod)
+				if err := common.EnsureIndex(indexCtx, esClient, name, alias, logger); err != nil {
+					return fmt.Errorf("failed to ensure index for %s: %w", alias, err)
 				}
 			}
-			ensureIndices()
+			return nil
+		}
+
+		if err := ensureIndices(); err != nil {
+			return err
+		}
+
+		go func() {
 			ticker := time.NewTicker(time.Minute)
 			defer ticker.Stop()
 			for {
@@ -236,7 +241,9 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					ensureIndices()
+					if err := ensureIndices(); err != nil {
+						logger.Error("%v", err)
+					}
 				}
 			}
 		}()


### PR DESCRIPTION
## Summary

This PR hardens ingest and expiry startup behavior to prevent Elasticsearch alias write-target errors introduced by recent index/alias changes.

Specifically, it addresses failures like:

- `illegal_argument_exception: no write index is defined for alias [likes]`
- `illegal_argument_exception: no write index is defined for alias [posts]`

## Why

Several services can begin processing before aliases have a valid `is_write_index` target. If an alias points to multiple indices without a designated write index, write operations fail at runtime.

This PR makes alias setup a startup requirement instead of a best-effort background action.

## What changed

- Made initial alias/index enforcement synchronous (fail-fast) in ingest services.
- Kept periodic background alias enforcement for rollover handling.
- Added `posts` alias enforcement to Jetstream startup, since Jetstream updates post like counts through the `posts` alias.
- Added startup alias enforcement in the expiry job for `hashtags` before running delete-by-query (non-dry-run).

## Behavior change

- Services now fail on startup if required aliases cannot be ensured.
- Services no longer start processing and then fail mid-run due to missing write-index designation.
