### PR TITLE
Scale back production CPU — PR 1 of 2 (master 500m→400m, data 3000m→2500m)

### DIFF
--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -35,10 +35,10 @@ patches:
         value: 6Gi
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/requests/cpu
-        value: "500m"
+        value: "400m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/limits/cpu
-        value: "500m"
+        value: "400m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/env/0/value
         value: "-Xms3g -Xmx3g"
@@ -61,10 +61,10 @@ patches:
                 resources:
                   requests:
                     memory: 32Gi
-                    cpu: "3000m"
+                    cpu: "2500m"
                   limits:
                     memory: 32Gi
-                    cpu: "3000m"
+                    cpu: "2500m"
                 env:
                 - name: ES_JAVA_OPTS
                   value: "-Xms16g -Xmx16g"


### PR DESCRIPTION
Part of #306

ILM (#264) replaced the `elasticsearch_expiry` scheduled job, eliminating the evening CPU spikes that previously blocked further reduction. Based on 24h GCP monitoring (Apr 25–26 2026), data nodes peak at ~37% of 3000m and master nodes at ~13%, leaving significant headroom. This is PR 1 of 2, reducing CPU by the first half of the planned total reduction.

# This PR

Updates `index/deploy/k8s/environments/prod/kustomization.yaml` with reduced CPU requests and limits:

- Master nodes (×2): CPU requests and limits `500m` → `400m`
- Data nodes (×4): CPU requests and limits `3000m` → `2500m`

# Testing

- Unit tests pass: `cd ingest && go test ./internal/common/... -v`
- Lint clean: `golangci-lint run`
- Deploy with `cd index && ./deploy.sh prod --ctypes resource` and verify all `greenearth-es-*` pods return to `Running` / `1/1 Ready`
- Monitor GCP Cloud Monitoring CPU utilization for ≥30 minutes at peak load before merging

# Deployment or Migration Plan

1. Merge this PR
2. Run `cd index && ./deploy.sh prod --ctypes resource`
3. Confirm `kubectl get pods -n greenearth-prod` shows all `greenearth-es-*` pods `Running` / `1/1 Ready`
4. Monitor GCP Cloud Monitoring CPU utilization at peak for ≥30 minutes
5. Once confirmed healthy, open PR 2 (`issue.306-pt2`) for the second half of the reduction (master 400m→300m, data 2500m→2000m)

Deploy to prod.