### PR TITLE
Fix JetStream startup loop and WebSocket panic

### DIFF
--- a/ingest/cmd/jetstream_ingest/main.go
+++ b/ingest/cmd/jetstream_ingest/main.go
@@ -156,9 +156,23 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 			return nil
 		}
 
-		if err := ensureIndices(); err != nil {
-			logger.Error("%v", err)
-			os.Exit(1)
+		{
+			backoff := time.Second
+			for {
+				if err := ensureIndices(); err == nil {
+					break
+				} else {
+					logger.Error("ensureIndices failed (retrying in %v): %v", backoff, err)
+				}
+				select {
+				case <-time.After(backoff):
+				case <-ctx.Done():
+					return
+				}
+				if backoff < 60*time.Second {
+					backoff *= 2
+				}
+			}
 		}
 
 		go func() {

--- a/ingest/internal/common/elasticsearch.go
+++ b/ingest/internal/common/elasticsearch.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -2093,13 +2094,14 @@ func EnsureIndex(ctx context.Context, client *elasticsearch.Client, indexName, a
 	}()
 
 	if createRes.IsError() {
+		bodyBytes, _ := io.ReadAll(createRes.Body)
 		var errBody struct {
 			Error struct {
 				Type string `json:"type"`
 			} `json:"error"`
 		}
-		if jerr := json.NewDecoder(createRes.Body).Decode(&errBody); jerr != nil || errBody.Error.Type != "resource_already_exists_exception" {
-			return fmt.Errorf("create index %s: %s", indexName, createRes.String())
+		if jerr := json.Unmarshal(bodyBytes, &errBody); jerr != nil || errBody.Error.Type != "resource_already_exists_exception" {
+			return fmt.Errorf("create index %s: [%d] %s", indexName, createRes.StatusCode, string(bodyBytes))
 		}
 	} else {
 		logger.Info("Created index %s", indexName)

--- a/ingest/internal/common/elasticsearch_ensure_index_test.go
+++ b/ingest/internal/common/elasticsearch_ensure_index_test.go
@@ -1,0 +1,113 @@
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v9"
+)
+
+// mockESHandler returns an HTTP handler that responds to ES index creation requests.
+type mockESHandler struct {
+	statusCode int
+	body       string
+}
+
+func (m *mockESHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.Header().Set("X-Elastic-Product", "Elasticsearch")
+	w.WriteHeader(m.statusCode)
+	_, _ = w.Write([]byte(m.body))
+}
+
+func newMockESClient(t *testing.T, handler http.Handler) (*elasticsearch.Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	client, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{srv.URL},
+	})
+	if err != nil {
+		srv.Close()
+		t.Fatalf("failed to create mock ES client: %v", err)
+	}
+	return client, srv
+}
+
+func TestEnsureIndex_NonResourceAlreadyExistsError_IncludesBody(t *testing.T) {
+	errBody := `{"error":{"type":"illegal_argument_exception","reason":"too many shards"},"status":400}`
+	handler := &mockESHandler{statusCode: 400, body: errBody}
+	client, srv := newMockESClient(t, handler)
+	defer srv.Close()
+
+	logger := NewLogger(false)
+	err := EnsureIndex(t.Context(), client, "likes-2026-04-27-00", "likes", logger)
+
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "illegal_argument_exception") {
+		t.Errorf("error should contain the ES error type from the response body; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "too many shards") {
+		t.Errorf("error should contain the ES reason from the response body; got: %v", err)
+	}
+}
+
+func TestEnsureIndex_ResourceAlreadyExists_IsNotAnError(t *testing.T) {
+	// Sequence of responses:
+	// 1. PUT /likes-2026-04-27-00 → 400 resource_already_exists_exception
+	// 2. GET /_alias/likes → 200 with index already as write target
+	// Subsequent calls return 404 for anything else.
+	responses := []struct {
+		code int
+		body string
+	}{
+		// Create index → already exists
+		{400, `{"error":{"type":"resource_already_exists_exception","reason":"index already exists"},"status":400}`},
+		// GetAlias → index is already the write target
+		{200, `{"likes-2026-04-27-00":{"aliases":{"likes":{"is_write_index":true}}}}`},
+	}
+	idx := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		if idx < len(responses) {
+			w.WriteHeader(responses[idx].code)
+			_, _ = w.Write([]byte(responses[idx].body))
+			idx++
+		} else {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	client, err := elasticsearch.NewClient(elasticsearch.Config{Addresses: []string{srv.URL}})
+	if err != nil {
+		t.Fatalf("failed to create ES client: %v", err)
+	}
+
+	logger := NewLogger(false)
+	err = EnsureIndex(t.Context(), client, "likes-2026-04-27-00", "likes", logger)
+	if err != nil {
+		t.Errorf("expected no error when index already exists as write target; got: %v", err)
+	}
+}
+
+func TestEnsureIndex_EmptyErrorBody_ReturnsStatusCode(t *testing.T) {
+	handler := &mockESHandler{statusCode: 400, body: ""}
+	client, srv := newMockESClient(t, handler)
+	defer srv.Close()
+
+	logger := NewLogger(false)
+	err := EnsureIndex(t.Context(), client, "likes-2026-04-27-00", "likes", logger)
+
+	if err == nil {
+		t.Fatal("expected an error for empty 400 body, got nil")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error should include the HTTP status code; got: %v", err)
+	}
+}

--- a/ingest/internal/jetstream_ingest/client.go
+++ b/ingest/internal/jetstream_ingest/client.go
@@ -92,107 +92,75 @@ func (c *Client) Start(ctx context.Context) error {
 func (c *Client) readLoop(ctx context.Context) {
 	defer close(c.msgChan)
 
-	for {
-		select {
-		case <-ctx.Done():
-			c.logger.Info("Context cancelled, closing WebSocket connection")
-			c.mu.Lock()
-			c.reconnect = false
-			if c.conn != nil {
-				if err := c.conn.Close(); err != nil {
-					c.logger.Error("Failed to close WebSocket connection: %v", err)
-				}
+	// Close the active connection when ctx is cancelled so ReadMessage unblocks.
+	go func() {
+		<-ctx.Done()
+		c.mu.Lock()
+		c.reconnect = false
+		if c.conn != nil {
+			if err := c.conn.Close(); err != nil {
+				c.logger.Error("Failed to close WebSocket connection on shutdown: %v", err)
 			}
-			c.mu.Unlock()
-			return
-		default:
-			c.mu.RLock()
-			conn := c.conn
-			shouldReconnect := c.reconnect
-			c.mu.RUnlock()
+		}
+		c.mu.Unlock()
+	}()
 
-			if conn == nil {
-				if !shouldReconnect {
+	for {
+		c.mu.RLock()
+		conn := c.conn
+		shouldReconnect := c.reconnect
+		c.mu.RUnlock()
+
+		if conn == nil {
+			if !shouldReconnect {
+				return
+			}
+			c.logger.Info("Attempting to reconnect...")
+			if err := c.Connect(ctx); err != nil {
+				c.logger.Error("Reconnection failed: %v, retrying in 5 seconds", err)
+				select {
+				case <-time.After(5 * time.Second):
+				case <-ctx.Done():
 					return
 				}
-				c.logger.Info("Attempting to reconnect...")
-				if err := c.Connect(ctx); err != nil {
-					c.logger.Error("Reconnection failed: %v, retrying in 5 seconds", err)
-					// Use a timer with context checking instead of blocking sleep
-					select {
-					case <-time.After(5 * time.Second):
-					case <-ctx.Done():
-						return
-					}
-					continue
-				}
-				c.mu.RLock()
-				conn = c.conn
-				c.mu.RUnlock()
-			}
-
-			// Set read deadline to allow periodic context checking
-			if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
-				c.logger.Error("Failed to set read deadline: %v", err)
 				continue
 			}
+			c.mu.RLock()
+			conn = c.conn
+			c.mu.RUnlock()
+		}
 
-			_, message, err := conn.ReadMessage()
-			if err != nil {
-				if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-					c.logger.Info("WebSocket connection closed normally")
-					c.mu.Lock()
-					c.conn = nil
-					shouldReconnect := c.reconnect
-					c.mu.Unlock()
-					if shouldReconnect {
-						c.logger.Info("Reconnecting in 5 seconds...")
-						// Use a timer with context checking instead of blocking sleep
-						select {
-						case <-time.After(5 * time.Second):
-						case <-ctx.Done():
-							return
-						}
-						continue
-					}
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			if ctx.Err() != nil {
+				return // ctx cancelled — the shutdown goroutine closed the conn
+			}
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				c.logger.Info("WebSocket connection closed normally")
+			} else {
+				c.logger.Error("Error reading from WebSocket: %v", err)
+			}
+			c.mu.Lock()
+			c.conn = nil
+			shouldReconnect = c.reconnect
+			c.mu.Unlock()
+			if shouldReconnect {
+				c.logger.Info("Reconnecting in 5 seconds...")
+				select {
+				case <-time.After(5 * time.Second):
+				case <-ctx.Done():
 					return
 				}
-
-				// Check if it's a timeout (which is expected due to read deadline)
-				if netErr, ok := err.(interface{ Timeout() bool }); ok && netErr.Timeout() {
-					continue
-				}
-
-				c.logger.Error("Error reading from WebSocket: %v", err)
-				c.mu.Lock()
-				c.conn = nil
-				shouldReconnect := c.reconnect
-				c.mu.Unlock()
-				if shouldReconnect {
-					c.logger.Info("Reconnecting in 5 seconds...")
-					// Use a timer with context checking instead of blocking sleep
-					select {
-					case <-time.After(5 * time.Second):
-					case <-ctx.Done():
-						return
-					}
-					continue
-				}
-				return
 			}
+			continue
+		}
 
-			// Send message to channel with blocking and timeout
-			// This applies backpressure when the consumer is slower than the producer
-			select {
-			case c.msgChan <- string(message):
-				// Message sent successfully
-			case <-time.After(5 * time.Second):
-				// If we can't send within 5 seconds, log and drop
-				c.logger.Error("Message channel full for 5 seconds, dropping message")
-			case <-ctx.Done():
-				// Context cancelled while trying to send
-				return
-			}
+		select {
+		case c.msgChan <- string(message):
+		case <-time.After(5 * time.Second):
+			c.logger.Error("Message channel full for 5 seconds, dropping message")
+		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/ingest/internal/jetstream_ingest/client_test.go
+++ b/ingest/internal/jetstream_ingest/client_test.go
@@ -272,6 +272,42 @@ func TestClientMessageChannelBufferFull(t *testing.T) {
 	}
 }
 
+// TestClientShutdownOnIdleConnection verifies that cancelling the context closes
+// the message channel even when the server is silent (no messages being sent).
+// This exercises the shutdown goroutine added to readLoop: previously the code
+// relied on a read deadline to break out of ReadMessage, which caused gorilla to
+// permanently mark the connection as failed and panic on the next read.
+func TestClientShutdownOnIdleConnection(t *testing.T) {
+	logger := common.NewLogger(false)
+
+	// Server accepts the connection but never sends any messages.
+	server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
+		time.Sleep(5 * time.Second)
+	})
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	client := NewClient(wsURL, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("Failed to start client: %v", err)
+	}
+
+	// Cancel the context while ReadMessage is blocking (no deadline set).
+	cancel()
+
+	// The shutdown goroutine should close the connection, unblocking ReadMessage
+	// and causing readLoop to exit, which closes msgChan.
+	select {
+	case <-client.GetMessageChannel():
+		// channel closed — shutdown completed
+	case <-time.After(2 * time.Second):
+		t.Fatal("message channel did not close within 2 s after context cancellation")
+	}
+}
+
 func TestGetMessageChannel(t *testing.T) {
 	logger := common.NewLogger(false)
 	client := NewClient("ws://example.com/subscribe", logger)


### PR DESCRIPTION
On 2026-04-27 at ~00:43 UTC, the JetStream ingest service entered a continuous Cloud Run restart loop after a gorilla/websocket panic killed the process. The restart loop was caused by `ensureIndices` hard-exiting on every startup attempt due to a 400 from Elasticsearch — and the error body was being silently consumed before logging, making the actual ES error impossible to diagnose.

# This PR

Three fixes addressing the cascade that caused the outage:

- **Fix WebSocket panic** (`client.go`): gorilla/websocket v1.5.3 permanently marks a connection as failed after any error including deadline-exceeded timeouts, then panics if `ReadMessage` is called again. The old code reused the connection after timeouts. Replaced the read-deadline-based ctx polling with a dedicated shutdown goroutine that closes the connection when ctx is cancelled — `ReadMessage` now blocks cleanly until a real message or explicit close.
- **Fix startup restart loop** (`main.go`): replaced `os.Exit(1)` on `ensureIndices` failure with exponential backoff retry (1 s → 2 s → ... → 60 s cap). The service now blocks at startup waiting for ES instead of triggering a rapid Cloud Run restart loop.
- **Fix ES error body consumed before logging** (`elasticsearch.go`): `json.Decode` was consuming the response body stream, so `createRes.String()` always returned `[400 Bad Request] ` with no details. Now uses `io.ReadAll` + `json.Unmarshal` so the full body is available for both type-checking and error formatting. Required to diagnose the underlying 400 after deployment.

# Testing

- `go test ./internal/common/... ./internal/jetstream_ingest/...` — passes (3 new EnsureIndex tests + 1 new client shutdown test)
- `golangci-lint run` — 0 issues
- `go build ./cmd/jetstream_ingest/...` — clean build