### PR TITLE
Fix GE_INDEX_PERIOD derived before --environment flag is parsed

### DIFF
--- a/ingest/scripts/deploy.sh
+++ b/ingest/scripts/deploy.sh
@@ -21,16 +21,6 @@ GE_AWS_S3_PREFIX="${GE_AWS_S3_PREFIX:-mega/}"
 GE_JETSTREAM_INSTANCES="${GE_JETSTREAM_INSTANCES:-1}"
 GE_MEGASTREAM_INSTANCES="${GE_MEGASTREAM_INSTANCES:-1}"
 
-# Index period: controls time-based index partitioning for posts/likes/tombstones
-# prod → week (ISO week), stage → hour, local/default → 10min
-if [ "$GE_ENVIRONMENT" = "prod" ]; then
-    GE_INDEX_PERIOD="${GE_INDEX_PERIOD:-week}"
-elif [ "$GE_ENVIRONMENT" = "stage" ]; then
-    GE_INDEX_PERIOD="${GE_INDEX_PERIOD:-hour}"
-else
-    GE_INDEX_PERIOD="${GE_INDEX_PERIOD:-10min}"
-fi
-
 # Get current git SHA (short version) for deployment tracking
 GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
@@ -484,9 +474,22 @@ show_service_status() {
 main() {
     local service="${1:-all}"
 
+    # Derive GE_INDEX_PERIOD from GE_ENVIRONMENT after all flags have been parsed.
+    # Using unconditional assignment so a stale GE_INDEX_PERIOD in the caller's
+    # shell cannot override the environment-appropriate value.
+    # prod → week (ISO week), stage → hour, local/default → 10min
+    if [ "$GE_ENVIRONMENT" = "prod" ]; then
+        GE_INDEX_PERIOD="week"
+    elif [ "$GE_ENVIRONMENT" = "stage" ]; then
+        GE_INDEX_PERIOD="hour"
+    else
+        GE_INDEX_PERIOD="10min"
+    fi
+
     echo "=================================================="
     echo "Green Earth Ingex - Cloud Run Source Deployment"
     echo "Environment: $GE_ENVIRONMENT"
+    echo "Index period: $GE_INDEX_PERIOD"
     echo "Project: $GE_GCP_PROJECT_ID"
     echo "Region: $GE_GCP_REGION"
     echo "Git SHA: $GIT_SHA"


### PR DESCRIPTION
Closes #346

`GE_INDEX_PERIOD` was being derived from `GE_ENVIRONMENT` at the top of the script, before the argument-parsing loop ran. This meant that `./deploy.sh --environment prod` would evaluate the `if/elif` block while `GE_ENVIRONMENT` was still `"stage"` (the default), setting `GE_INDEX_PERIOD=hour`. By the time `--environment prod` was parsed and `GE_ENVIRONMENT` updated, `GE_INDEX_PERIOD` was already wrong. The prod ingest services were then deployed with the stage index period, causing hourly indices to accumulate on the prod Elasticsearch cluster alongside the existing weekly indices and eventually exhausting shard capacity (3996/4000).

# This PR

- Move `GE_INDEX_PERIOD` derivation into `main()`, after the flag-parsing loop, so `GE_ENVIRONMENT` reflects any `--environment` override before the period is computed
- Switch from `${GE_INDEX_PERIOD:-value}` (only fills in if unset) to unconditional assignment so a stale `GE_INDEX_PERIOD` left over in the caller's shell cannot override the environment-appropriate value
- Add `Index period: $GE_INDEX_PERIOD` to the deploy banner so the value is always visible and easy to catch before services are deployed

# Testing

- Verified `./scripts/deploy.sh --environment prod` now sets `GE_INDEX_PERIOD=week` in the banner
- Verified `./scripts/deploy.sh --environment stage` sets `GE_INDEX_PERIOD=hour`
- Verified `./scripts/deploy.sh` (no flag, defaults to stage) sets `GE_INDEX_PERIOD=hour`