### PR TITLE
Reduce ES node CPU requests

### DIFF
--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -35,10 +35,10 @@ patches:
         value: 6Gi
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/requests/cpu
-        value: "400m"
+        value: "200m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/limits/cpu
-        value: "400m"
+        value: "200m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/env/0/value
         value: "-Xms3g -Xmx3g"
@@ -61,10 +61,10 @@ patches:
                 resources:
                   requests:
                     memory: 32Gi
-                    cpu: "2500m"
+                    cpu: "1250m"
                   limits:
                     memory: 32Gi
-                    cpu: "2500m"
+                    cpu: "1250m"
                 env:
                 - name: ES_JAVA_OPTS
                   value: "-Xms16g -Xmx16g"

--- a/index/deploy/k8s/environments/stage/kustomization.yaml
+++ b/index/deploy/k8s/environments/stage/kustomization.yaml
@@ -35,10 +35,10 @@ patches:
         value: 2Gi
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/requests/cpu
-        value: "500m"
+        value: "200m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/resources/limits/cpu
-        value: "500m"
+        value: "200m"
       - op: replace
         path: /spec/nodeSets/0/podTemplate/spec/containers/0/env/0/value
         value: "-Xms1g -Xmx1g"
@@ -61,10 +61,10 @@ patches:
                 resources:
                   requests:
                     memory: 10Gi
-                    cpu: "2250m"
+                    cpu: "1000m"
                   limits:
                     memory: 10Gi
-                    cpu: "2250m"
+                    cpu: "1000m"
                 env:
                 - name: ES_JAVA_OPTS
                   value: "-Xms5g -Xmx5g"


### PR DESCRIPTION
Closes #306
Closes #349

Elasticsearch CPU requests are higher than needed for both master and data node pools; reducing them to free up cluster capacity.

# This PR

- Reduce prod master node CPU request/limit: 400m → 200m
- Reduce prod data node CPU request/limit: 2500m → 1250m
- Reduce stage master node CPU request/limit: 500m → 200m
- Reduce stage data node CPU request/limit: 2250m → 1000m

# Testing

- Deploy to stage: `cd index && ./deploy.sh stage --ctypes resource`
- Deploy to prod: `cd index && ./deploy.sh prod --ctypes resource`

Before:

<img width="1858" height="340" alt="Screenshot 2026-05-12 at 9 32 18 PM" src="https://github.com/user-attachments/assets/6dfccf4c-aef3-4583-9a9a-f6c01321901f" />
