### PR TITLE
feat: separate replies into dedicated replies Elasticsearch index (#359)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ export GE_BLOCKLIST_DESTINATION="gs://${GE_GCP_PROJECT_ID}-ingex-blocklist-${GE_
 export GE_PARQUET_DESTINATION="gs://bucket OR /local/path"
 export GE_PARQUET_MAX_RECORDS=1000000
 export GE_EXTRACT_FETCH_SIZE=5000
-export GE_EXTRACT_INDICES="posts,likes"
+export GE_EXTRACT_INDICES="posts,likes,replies"
 
 ########### Index Variables ############
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ claude.md
 ingest/extract
 ingest/elasticsearch_expiry
 ingest/megastream_ingest
+ingest/jetstream_ingest

--- a/index/deploy/k8s/base/bootstrap-job.yaml
+++ b/index/deploy/k8s/base/bootstrap-job.yaml
@@ -52,6 +52,11 @@ spec:
             -H "Content-Type: application/json" \
             -d "$ILM_DELETE_POLICY"
 
+          curl -k --fail-with-body -X PUT "https://greenearth-es-http:9200/_ilm/policy/replies_ilm_policy" \
+            -u "es-service-user:$ES_SERVICE_PASSWORD" \
+            -H "Content-Type: application/json" \
+            -d "$ILM_DELETE_POLICY"
+
           curl -k --fail-with-body -X PUT "https://greenearth-es-http:9200/_ilm/policy/likes_ilm_policy" \
             -u "es-service-user:$ES_SERVICE_PASSWORD" \
             -H "Content-Type: application/json" \
@@ -134,6 +139,20 @@ spec:
             -d @/templates/post-tombstones-ilm-index-template.json
           echo "post_tombstones_ilm_template completed!"
 
+          echo "Applying replies_ilm_template template..."
+          curl -k -X PUT "https://greenearth-es-http:9200/_index_template/replies_ilm_template" \
+            -u "es-service-user:$ES_SERVICE_PASSWORD" \
+            -H "Content-Type: application/json" \
+            -d @/templates/replies-ilm-index-template.json
+          echo "replies_ilm_template completed!"
+
+          echo "Applying reply_tombstones_ilm_template template..."
+          curl -k -X PUT "https://greenearth-es-http:9200/_index_template/reply_tombstones_ilm_template" \
+            -u "es-service-user:$ES_SERVICE_PASSWORD" \
+            -H "Content-Type: application/json" \
+            -d @/templates/reply-tombstones-ilm-index-template.json
+          echo "reply_tombstones_ilm_template completed!"
+
           echo "Applying like_tombstones_ilm_template template..."
           curl -k -X PUT "https://greenearth-es-http:9200/_index_template/like_tombstones_ilm_template" \
             -u "es-service-user:$ES_SERVICE_PASSWORD" \
@@ -184,6 +203,10 @@ spec:
               name: post-tombstones-ilm-index-template
           - configMap:
               name: like-tombstones-ilm-index-template
+          - configMap:
+              name: replies-ilm-index-template
+          - configMap:
+              name: reply-tombstones-ilm-index-template
       - name: aliases
         projected:
           sources:

--- a/index/deploy/k8s/base/elasticsearch-snapshot-setup-job.yaml
+++ b/index/deploy/k8s/base/elasticsearch-snapshot-setup-job.yaml
@@ -71,7 +71,7 @@ spec:
               \"name\": \"<snap-{now{yyyy-MM-dd-HH-mm}}>\",
               \"repository\": \"gcs_backup\",
               \"config\": {
-                \"indices\": [\"posts*\", \"post_tombstones*\", \"post-tombstones*\", \"hashtags*\", \"likes*\", \"like_tombstones*\", \"like-tombstones*\", \"inferences*\"],
+                \"indices\": [\"posts*\", \"post_tombstones*\", \"post-tombstones*\", \"replies*\", \"reply_tombstones*\", \"reply-tombstones*\", \"hashtags*\", \"likes*\", \"like_tombstones*\", \"like-tombstones*\", \"inferences*\"],
                 \"include_global_state\": false,
                 \"feature_states\": []
               },

--- a/index/deploy/k8s/base/kustomization.yaml
+++ b/index/deploy/k8s/base/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
   - templates/likes-ilm-index-template.yaml
   - templates/post-tombstones-ilm-index-template.yaml
   - templates/like-tombstones-ilm-index-template.yaml
+  - templates/replies-ilm-index-template.yaml
+  - templates/reply-tombstones-ilm-index-template.yaml
   - update-recent-alias-cronjob.yaml
 
 configMapGenerator:
@@ -48,6 +50,8 @@ configMapGenerator:
       - likes_index_replicas=0
       - tombstones_index_shards=1
       - tombstones_index_replicas=0
+      - replies_index_shards=1
+      - replies_index_replicas=0
       - ilm_delete_age=30m
       - index_period=10min
 
@@ -146,6 +150,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.tombstones_index_replicas
+  - name: REPLIES_INDEX_SHARDS
+    objref:
+      kind: ConfigMap
+      name: ilm-settings
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.replies_index_shards
+  - name: REPLIES_INDEX_REPLICAS
+    objref:
+      kind: ConfigMap
+      name: ilm-settings
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.replies_index_replicas
   - name: ILM_DELETE_AGE
     objref:
       kind: ConfigMap

--- a/index/deploy/k8s/base/templates/replies-ilm-index-template.yaml
+++ b/index/deploy/k8s/base/templates/replies-ilm-index-template.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: replies-ilm-index-template
+data:
+  replies-ilm-index-template.json: |
+    {
+      "index_patterns": ["replies-*"],
+      "template": {
+        "settings": {
+          "number_of_shards": $(REPLIES_INDEX_SHARDS),
+          "number_of_replicas": $(REPLIES_INDEX_REPLICAS),
+          "refresh_interval": "30s",
+          "translog.durability": "async",
+          "translog.sync_interval": "30s",
+          "lifecycle": {
+            "name": "replies_ilm_policy"
+          },
+          "analysis": {
+            "analyzer": {
+              "content_analyzer": {
+                "type": "standard",
+                "stopwords": "_english_"
+              }
+            }
+          }
+        },
+        "mappings": {
+          "_routing": {
+            "required": true
+          },
+          "properties": {
+            "at_uri": {
+              "type": "keyword",
+              "index": true
+            },
+            "author_did": {
+              "type": "keyword",
+              "index": true
+            },
+            "content": {
+              "type": "text",
+              "index": true,
+              "analyzer": "content_analyzer",
+              "fields": {
+                "raw": {
+                  "type": "keyword",
+                  "ignore_above": 10922
+                }
+              }
+            },
+            "created_at": {
+              "type": "date",
+              "format": "iso8601",
+              "index": true
+            },
+            "thread_root_post": {
+              "type": "keyword",
+              "index": true
+            },
+            "thread_parent_post": {
+              "type": "keyword",
+              "index": true
+            },
+            "quote_post": {
+              "type": "keyword",
+              "index": true
+            },
+            "embeddings": {
+              "type": "object",
+              "properties": {
+                "all_MiniLM_L12_v2": {
+                  "type": "dense_vector",
+                  "dims": 384,
+                  "index": true,
+                  "similarity": "cosine"
+                },
+                "all_MiniLM_L6_v2": {
+                  "type": "dense_vector",
+                  "dims": 384,
+                  "index": true,
+                  "similarity": "cosine"
+                },
+                "google_embeddinggemma_300m": {
+                  "type": "dense_vector",
+                  "dims": 768,
+                  "index": true,
+                  "similarity": "cosine"
+                }
+              }
+            },
+            "indexed_at": {
+              "type": "date",
+              "format": "iso8601"
+            },
+            "like_count": {
+              "type": "integer",
+              "index": true
+            },
+            "media": {
+              "type": "nested",
+              "properties": {
+                "id": {"type": "keyword", "index": true},
+                "media_type": {"type": "keyword", "index": true},
+                "mime_type": {"type": "keyword", "index": true},
+                "size": {"type": "long", "index": true},
+                "aspect_ratio": {"type": "float", "index": true},
+                "width": {"type": "integer", "index": true},
+                "height": {"type": "integer", "index": true},
+                "alt_text": {"type": "text", "index": true}
+              }
+            },
+            "contains_images": {"type": "boolean", "index": true},
+            "contains_video": {"type": "boolean", "index": true},
+            "image_count": {"type": "integer", "index": true},
+            "video_count": {"type": "integer", "index": true},
+            "media_count": {"type": "integer", "index": true},
+            "external_embed": {
+              "type": "object",
+              "properties": {
+                "uri": {"type": "keyword", "index": true},
+                "title": {"type": "text", "index": true},
+                "description": {"type": "text", "index": true, "analyzer": "content_analyzer"}
+              }
+            },
+            "video_transcript": {
+              "type": "text",
+              "index": true,
+              "analyzer": "content_analyzer"
+            },
+            "video_transcript_language": {
+              "type": "keyword",
+              "index": true
+            }
+          }
+        }
+      }
+    }

--- a/index/deploy/k8s/base/templates/reply-tombstones-ilm-index-template.yaml
+++ b/index/deploy/k8s/base/templates/reply-tombstones-ilm-index-template.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reply-tombstones-ilm-index-template
+data:
+  reply-tombstones-ilm-index-template.json: |
+    {
+      "index_patterns": ["reply-tombstones-*"],
+      "template": {
+        "settings": {
+          "number_of_shards": $(TOMBSTONES_INDEX_SHARDS),
+          "number_of_replicas": $(TOMBSTONES_INDEX_REPLICAS),
+          "refresh_interval": "30s",
+          "translog.durability": "async",
+          "translog.sync_interval": "30s",
+          "lifecycle": {
+            "name": "tombstones_ilm_policy"
+          }
+        },
+        "mappings": {
+          "_routing": {
+            "required": true
+          },
+          "properties": {
+            "at_uri": {
+              "type": "keyword",
+              "index": true
+            },
+            "author_did": {
+              "type": "keyword",
+              "index": true
+            },
+            "deleted_at": {
+              "type": "date",
+              "format": "iso8601"
+            },
+            "indexed_at": {
+              "type": "date",
+              "format": "iso8601"
+            }
+          }
+        }
+      }
+    }

--- a/index/deploy/k8s/environments/local/kustomization.yaml
+++ b/index/deploy/k8s/environments/local/kustomization.yaml
@@ -35,5 +35,7 @@ configMapGenerator:
       - likes_index_replicas=0
       - tombstones_index_shards=1
       - tombstones_index_replicas=0
+      - replies_index_shards=1
+      - replies_index_replicas=0
       - ilm_delete_age=30m
       - index_period=10min

--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -128,5 +128,7 @@ configMapGenerator:
       - likes_index_replicas=1
       - tombstones_index_shards=3
       - tombstones_index_replicas=1
+      - replies_index_shards=7
+      - replies_index_replicas=1
       - ilm_delete_age=60d
       - index_period=week

--- a/index/deploy/k8s/environments/stage/kustomization.yaml
+++ b/index/deploy/k8s/environments/stage/kustomization.yaml
@@ -122,5 +122,7 @@ configMapGenerator:
       - likes_index_replicas=1
       - tombstones_index_shards=1
       - tombstones_index_replicas=1
+      - replies_index_shards=2
+      - replies_index_replicas=1
       - ilm_delete_age=4h
       - index_period=hour

--- a/index/restore.sh
+++ b/index/restore.sh
@@ -137,7 +137,7 @@ else:
     log_info "Selected most recent successful snapshot: $SNAPSHOT_NAME"
 }
 
-SNAPSHOT_INDICES="posts*,post_tombstones*,post-tombstones*,hashtags*,likes*,like_tombstones*,like-tombstones*,inferences*"
+SNAPSHOT_INDICES="posts*,post_tombstones*,post-tombstones*,replies*,reply_tombstones*,reply-tombstones*,hashtags*,likes*,like_tombstones*,like-tombstones*,inferences*"
 
 delete_existing_indices() {
     log_info "Checking for existing indices on cluster..."

--- a/ingest/cmd/extract/README.md
+++ b/ingest/cmd/extract/README.md
@@ -26,7 +26,7 @@ Export data from Elasticsearch to Parquet files for analysis and archival.
 - `GE_PARQUET_DESTINATION`: Output destination - supports local paths (./output) or GCS paths (gs://bucket/path)
 - `GE_PARQUET_MAX_RECORDS`: Default max records per file (default: 100000)
 - `GE_EXTRACT_FETCH_SIZE`: Default fetch size (default: 1000)
-- `GE_EXTRACT_INDICES`: Comma-separated list of indices to export (default: "posts"). Supported values: `posts`, `likes`, `hashtags`
+- `GE_EXTRACT_INDICES`: Comma-separated list of indices to export (default: "posts"). Supported values: `posts`, `replies`, `likes`, `hashtags`
 - `GE_LOGGING_ENABLED`: Enable logging (default: true)
 
 ## Examples
@@ -57,7 +57,7 @@ export GE_PARQUET_DESTINATION="gs://my-bucket/exports/"
 ### Export multiple indices with rolling time window
 
 ```bash
-GE_EXTRACT_INDICES="posts,likes" ./extract --window-size-min 240
+GE_EXTRACT_INDICES="posts,likes,replies" ./extract --window-size-min 240
 ```
 
 ### Export with fixed time window

--- a/ingest/cmd/extract/main.go
+++ b/ingest/cmd/extract/main.go
@@ -537,7 +537,7 @@ func parseIndices(indicesStr string) []string {
 func ParseIndexType(indexName string) (IndexType, error) {
 	lowerName := strings.ToLower(indexName)
 
-	if strings.Contains(lowerName, "repl") {
+	if strings.Contains(lowerName, "replies") {
 		return IndexTypeReplies, nil
 	}
 

--- a/ingest/cmd/extract/main.go
+++ b/ingest/cmd/extract/main.go
@@ -206,6 +206,9 @@ func runExport(ctx context.Context, config *common.Config, logger *common.Ingest
 					logger.Metric("extract.inference_error_count", 1)
 				}
 			}
+		case IndexTypeReplies:
+			// Replies have the same schema as posts; no inferences export.
+			_, exportErr = runExportForPosts(ctx, esClient, logger, dryRun, outputPath, isGCS, gcsClient, gcsBucket, gcsPrefix, indexName, startTime, endTime, config)
 		case IndexTypeLikes:
 			exportErr = runExportForLikes(ctx, esClient, logger, dryRun, outputPath, isGCS, gcsClient, gcsBucket, gcsPrefix, indexName, startTime, endTime, config)
 		case IndexTypeHashtags:
@@ -490,6 +493,8 @@ func generateFilename(indexName, lastPostTimestamp string, logger *common.Ingest
 		typeStr = "likes"
 	case IndexTypeHashtags:
 		typeStr = "hashtags"
+	case IndexTypeReplies:
+		typeStr = "replies"
 	case IndexTypeUnknown:
 		typeStr = "unknown"
 	default:
@@ -506,6 +511,7 @@ const (
 	IndexTypePosts    IndexType = "posts"
 	IndexTypeLikes    IndexType = "likes"
 	IndexTypeHashtags IndexType = "hashtags"
+	IndexTypeReplies  IndexType = "replies"
 	IndexTypeUnknown  IndexType = ""
 )
 
@@ -531,6 +537,10 @@ func parseIndices(indicesStr string) []string {
 func ParseIndexType(indexName string) (IndexType, error) {
 	lowerName := strings.ToLower(indexName)
 
+	if strings.Contains(lowerName, "repl") {
+		return IndexTypeReplies, nil
+	}
+
 	if strings.Contains(lowerName, "post") {
 		return IndexTypePosts, nil
 	}
@@ -543,7 +553,7 @@ func ParseIndexType(indexName string) (IndexType, error) {
 		return IndexTypeHashtags, nil
 	}
 
-	return IndexTypeUnknown, fmt.Errorf("index name '%s' does not contain 'posts', 'likes', or 'hashtags'", indexName)
+	return IndexTypeUnknown, fmt.Errorf("index name '%s' does not contain 'replies', 'posts', 'likes', or 'hashtags'", indexName)
 }
 
 func getIndexType(indexName string, logger *common.IngestLogger) IndexType {

--- a/ingest/cmd/extract/main_test.go
+++ b/ingest/cmd/extract/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/greenearth/ingest/internal/common"
+)
+
+func TestParseIndexType_replies(t *testing.T) {
+	got, err := ParseIndexType("replies")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != IndexTypeReplies {
+		t.Errorf("expected IndexTypeReplies, got %q", got)
+	}
+}
+
+func TestParseIndexType_replies_periodName(t *testing.T) {
+	got, err := ParseIndexType("replies-2026-w23")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != IndexTypeReplies {
+		t.Errorf("expected IndexTypeReplies, got %q", got)
+	}
+}
+
+func TestGenerateFilename_replies(t *testing.T) {
+	logger := common.NewLogger(false)
+	filename := generateFilename("replies", "2026-06-06T12:00:00Z", logger)
+	if !strings.HasPrefix(filename, "bsky_replies_") {
+		t.Errorf("expected bsky_replies_ prefix, got %s", filename)
+	}
+}

--- a/ingest/cmd/jetstream_ingest/main.go
+++ b/ingest/cmd/jetstream_ingest/main.go
@@ -690,7 +690,7 @@ func esWorker(ctx context.Context, id int, batchChan <-chan batchJob, esClient *
 						}
 
 						for _, alias := range []string{"posts", "replies"} {
-							if err := common.BulkUpdatePostLikeCounts(ctx, esClient, alias, updates, dryRun, logger); err != nil {
+							if err := common.BulkUpdateLikeCounts(ctx, esClient, alias, updates, dryRun, logger); err != nil {
 								logger.Error("Worker %d: Failed to decrement post like counts in %s: %v", id, alias, err)
 								// Don't set success=false - this is a secondary operation
 							}
@@ -722,7 +722,7 @@ func esWorker(ctx context.Context, id int, batchChan <-chan batchJob, esClient *
 				}
 
 				for _, alias := range []string{"posts", "replies"} {
-					if err := common.BulkUpdatePostLikeCounts(ctx, esClient, alias, updates, dryRun, logger); err != nil {
+					if err := common.BulkUpdateLikeCounts(ctx, esClient, alias, updates, dryRun, logger); err != nil {
 						logger.Error("Worker %d: Failed to update post like counts in %s: %v", id, alias, err)
 						// Don't set success=false - this is a secondary operation
 					}

--- a/ingest/cmd/jetstream_ingest/main.go
+++ b/ingest/cmd/jetstream_ingest/main.go
@@ -147,7 +147,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 		ensureIndices := func() error {
 			indexCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			for _, alias := range []string{"likes", "like_tombstones", "posts"} {
+			for _, alias := range []string{"likes", "like_tombstones", "posts", "replies"} {
 				name := common.CurrentIndexName(alias, config.IndexPeriod)
 				if err := common.EnsureIndex(indexCtx, esClient, name, alias, logger); err != nil {
 					return fmt.Errorf("failed to ensure index for %s: %w", alias, err)
@@ -689,9 +689,11 @@ func esWorker(ctx context.Context, id int, batchChan <-chan batchJob, esClient *
 							}
 						}
 
-						if err := common.BulkUpdatePostLikeCounts(ctx, esClient, "posts", updates, dryRun, logger); err != nil {
-							logger.Error("Worker %d: Failed to decrement post like counts: %v", id, err)
-							// Don't set success=false - this is a secondary operation
+						for _, alias := range []string{"posts", "replies"} {
+							if err := common.BulkUpdatePostLikeCounts(ctx, esClient, alias, updates, dryRun, logger); err != nil {
+								logger.Error("Worker %d: Failed to decrement post like counts in %s: %v", id, alias, err)
+								// Don't set success=false - this is a secondary operation
+							}
 						}
 					}
 				}
@@ -719,9 +721,11 @@ func esWorker(ctx context.Context, id int, batchChan <-chan batchJob, esClient *
 					}
 				}
 
-				if err := common.BulkUpdatePostLikeCounts(ctx, esClient, "posts", updates, dryRun, logger); err != nil {
-					logger.Error("Worker %d: Failed to update post like counts: %v", id, err)
-					// Don't set success=false - this is a secondary operation
+				for _, alias := range []string{"posts", "replies"} {
+					if err := common.BulkUpdatePostLikeCounts(ctx, esClient, alias, updates, dryRun, logger); err != nil {
+						logger.Error("Worker %d: Failed to update post like counts in %s: %v", id, alias, err)
+						// Don't set success=false - this is a secondary operation
+					}
 				}
 			}
 		}

--- a/ingest/cmd/jetstream_ingest/main.go
+++ b/ingest/cmd/jetstream_ingest/main.go
@@ -689,12 +689,23 @@ func esWorker(ctx context.Context, id int, batchChan <-chan batchJob, esClient *
 							}
 						}
 
-						for _, alias := range []string{"posts", "replies"} {
-							if err := common.BulkUpdateLikeCounts(ctx, esClient, alias, updates, dryRun, logger); err != nil {
-								logger.Error("Worker %d: Failed to decrement post like counts in %s: %v", id, alias, err)
+						var wg sync.WaitGroup
+						wg.Add(2)
+						go func() {
+							defer wg.Done()
+							if err := common.BulkUpdateLikeCounts(ctx, esClient, "posts", updates, dryRun, logger); err != nil {
+								logger.Error("Worker %d: Failed to decrement post like counts in posts: %v", id, err)
 								// Don't set success=false - this is a secondary operation
 							}
-						}
+						}()
+						go func() {
+							defer wg.Done()
+							if err := common.BulkUpdateLikeCounts(ctx, esClient, "replies", updates, dryRun, logger); err != nil {
+								logger.Error("Worker %d: Failed to decrement post like counts in replies: %v", id, err)
+								// Don't set success=false - this is a secondary operation
+							}
+						}()
+						wg.Wait()
 					}
 				}
 			}
@@ -721,12 +732,23 @@ func esWorker(ctx context.Context, id int, batchChan <-chan batchJob, esClient *
 					}
 				}
 
-				for _, alias := range []string{"posts", "replies"} {
-					if err := common.BulkUpdateLikeCounts(ctx, esClient, alias, updates, dryRun, logger); err != nil {
-						logger.Error("Worker %d: Failed to update post like counts in %s: %v", id, alias, err)
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					if err := common.BulkUpdateLikeCounts(ctx, esClient, "posts", updates, dryRun, logger); err != nil {
+						logger.Error("Worker %d: Failed to update post like counts in posts: %v", id, err)
 						// Don't set success=false - this is a secondary operation
 					}
-				}
+				}()
+				go func() {
+					defer wg.Done()
+					if err := common.BulkUpdateLikeCounts(ctx, esClient, "replies", updates, dryRun, logger); err != nil {
+						logger.Error("Worker %d: Failed to update post like counts in replies: %v", id, err)
+						// Don't set success=false - this is a secondary operation
+					}
+				}()
+				wg.Wait()
 			}
 		}
 

--- a/ingest/cmd/jetstream_ingest/main.go
+++ b/ingest/cmd/jetstream_ingest/main.go
@@ -691,20 +691,8 @@ func esWorker(ctx context.Context, id int, batchChan <-chan batchJob, esClient *
 
 						var wg sync.WaitGroup
 						wg.Add(2)
-						go func() {
-							defer wg.Done()
-							if err := common.BulkUpdateLikeCounts(ctx, esClient, "posts", updates, dryRun, logger); err != nil {
-								logger.Error("Worker %d: Failed to decrement post like counts in posts: %v", id, err)
-								// Don't set success=false - this is a secondary operation
-							}
-						}()
-						go func() {
-							defer wg.Done()
-							if err := common.BulkUpdateLikeCounts(ctx, esClient, "replies", updates, dryRun, logger); err != nil {
-								logger.Error("Worker %d: Failed to decrement post like counts in replies: %v", id, err)
-								// Don't set success=false - this is a secondary operation
-							}
-						}()
+						go common.BulkIndexWorker(&wg, ctx, esClient, "posts", updates, dryRun, logger, common.BulkUpdateLikeCounts, "decrement like counts in")
+						go common.BulkIndexWorker(&wg, ctx, esClient, "replies", updates, dryRun, logger, common.BulkUpdateLikeCounts, "decrement like counts in")
 						wg.Wait()
 					}
 				}
@@ -734,20 +722,8 @@ func esWorker(ctx context.Context, id int, batchChan <-chan batchJob, esClient *
 
 				var wg sync.WaitGroup
 				wg.Add(2)
-				go func() {
-					defer wg.Done()
-					if err := common.BulkUpdateLikeCounts(ctx, esClient, "posts", updates, dryRun, logger); err != nil {
-						logger.Error("Worker %d: Failed to update post like counts in posts: %v", id, err)
-						// Don't set success=false - this is a secondary operation
-					}
-				}()
-				go func() {
-					defer wg.Done()
-					if err := common.BulkUpdateLikeCounts(ctx, esClient, "replies", updates, dryRun, logger); err != nil {
-						logger.Error("Worker %d: Failed to update post like counts in replies: %v", id, err)
-						// Don't set success=false - this is a secondary operation
-					}
-				}()
+				go common.BulkIndexWorker(&wg, ctx, esClient, "posts", updates, dryRun, logger, common.BulkUpdateLikeCounts, "increment like counts in")
+				go common.BulkIndexWorker(&wg, ctx, esClient, "replies", updates, dryRun, logger, common.BulkUpdateLikeCounts, "increment like counts in")
 				wg.Wait()
 			}
 		}

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -319,24 +320,20 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				// Flush post creation batch
 				if len(msgs) > 0 {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					count, err := indexPosts(batchCtx, msgs, esClient, dryRun, logger)
+					count := indexPosts(batchCtx, msgs, esClient, dryRun, logger, "account deletion flush")
 					processedCount += count
-					if err != nil {
-						logger.Error("Failed to index batch before account deletion: %v", err)
+					// Check if a newer instance has started (every 1000 docs to avoid excessive GCS reads)
+					if processedCount%1000 == 0 {
+						if stateManager.CheckForNewerInstance(myStartTime) {
+							logger.Info("Newer instance detected, exiting")
+							cancelBatchCtx()
+							goto cleanup
+						}
+					}
+					if dryRun {
+						logger.Info("Dry-run: Would index batch before account deletion: %d documents", count)
 					} else {
-						// Check if a newer instance has started (every 1000 docs to avoid excessive GCS reads)
-						if processedCount%1000 == 0 {
-							if stateManager.CheckForNewerInstance(myStartTime) {
-								logger.Info("Newer instance detected, exiting")
-								cancelBatchCtx()
-								goto cleanup
-							}
-						}
-						if dryRun {
-							logger.Info("Dry-run: Would index batch before account deletion: %d documents", count)
-						} else {
-							logger.Info("Indexed batch before account deletion: %d documents", count)
-						}
+						logger.Info("Indexed batch before account deletion: %d documents", count)
 					}
 					msgs = msgs[:0]
 
@@ -448,31 +445,27 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 
 				if len(msgs) >= batchSize {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					count, err := indexPosts(batchCtx, msgs, esClient, dryRun, logger)
+					count := indexPosts(batchCtx, msgs, esClient, dryRun, logger, "main batch loop")
 					processedCount += count
-					if err != nil {
-						logger.Error("Failed to bulk index batch: %v", err)
+					if lastMsg := msgs[len(msgs)-1]; lastMsg.GetTimeUs() > 0 {
+						logger.Metric("freshness_sec", float64(common.CalculateFreshness(lastMsg.GetTimeUs())))
+					}
+					// Check if a newer instance has started (every 1000 docs to avoid excessive GCS reads)
+					if processedCount%1000 == 0 {
+						if stateManager.CheckForNewerInstance(myStartTime) {
+							logger.Info("Newer instance detected, exiting")
+							cancelBatchCtx()
+							goto cleanup
+						}
+					}
+					if dryRun {
+						logger.Debug("Dry-run: Would index batch: %d documents (total: %d, deleted: %d, skipped: %d)", count, processedCount, deletedCount, skippedCount)
 					} else {
-						if lastMsg := msgs[len(msgs)-1]; lastMsg.GetTimeUs() > 0 {
-							logger.Metric("freshness_sec", float64(common.CalculateFreshness(lastMsg.GetTimeUs())))
-						}
-						// Check if a newer instance has started (every 1000 docs to avoid excessive GCS reads)
-						if processedCount%1000 == 0 {
-							if stateManager.CheckForNewerInstance(myStartTime) {
-								logger.Info("Newer instance detected, exiting")
-								cancelBatchCtx()
-								goto cleanup
-							}
-						}
-						if dryRun {
-							logger.Debug("Dry-run: Would index batch: %d documents (total: %d, deleted: %d, skipped: %d)", count, processedCount, deletedCount, skippedCount)
-						} else {
-							logger.Debug("Indexed batch: %d documents (total: %d, deleted: %d, skipped: %d)", count, processedCount, deletedCount, skippedCount)
-						}
-						// Log info every 100 batches (~10k documents)
-						if (processedCount / count % 100) == 0 {
-							logger.Info("Progress: %d documents processed (deleted: %d, skipped: %d)", processedCount, deletedCount, skippedCount)
-						}
+						logger.Debug("Indexed batch: %d documents (total: %d, deleted: %d, skipped: %d)", count, processedCount, deletedCount, skippedCount)
+					}
+					// Log info every 100 batches (~10k documents)
+					if count > 0 && (processedCount/count%100) == 0 {
+						logger.Info("Progress: %d documents processed (deleted: %d, skipped: %d)", processedCount, deletedCount, skippedCount)
 					}
 					msgs = msgs[:0]
 
@@ -516,16 +509,12 @@ cleanup:
 
 	// Index remaining documents in batch
 	if len(msgs) > 0 {
-		count, err := indexPosts(cleanupCtx, msgs, esClient, dryRun, logger)
+		count := indexPosts(cleanupCtx, msgs, esClient, dryRun, logger, "cleanup")
 		processedCount += count
-		if err != nil {
-			logger.Error("Failed to bulk index final batch: %v", err)
+		if dryRun {
+			logger.Debug("Dry-run: Would index final batch: %d documents", count)
 		} else {
-			if dryRun {
-				logger.Debug("Dry-run: Would index final batch: %d documents", count)
-			} else {
-				logger.Debug("Indexed final batch: %d documents", count)
-			}
+			logger.Debug("Indexed final batch: %d documents", count)
 		}
 	}
 
@@ -596,11 +585,12 @@ func postAliasFromDoc(doc common.ElasticsearchDoc) string {
 }
 
 // indexPosts creates Elasticsearch documents from messages and indexes them
-// Like counts start at 0 and are incremented by jetstream when likes arrive
-// Returns the number of documents indexed
-func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *elasticsearch.Client, dryRun bool, logger *common.IngestLogger) (int, error) {
+// concurrently — posts and replies are sent to ES in parallel goroutines.
+// Like counts start at 0 and are incremented by jetstream when likes arrive.
+// Returns the number of documents successfully indexed.
+func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *elasticsearch.Client, dryRun bool, logger *common.IngestLogger, batchContext string) int {
 	if len(msgs) == 0 {
-		return 0, nil
+		return 0
 	}
 
 	postsBatch := make([]common.ElasticsearchDoc, 0, len(msgs))
@@ -615,27 +605,38 @@ func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *
 		}
 	}
 
-	indexedCount := 0
-	var firstErr error
+	var (
+		postsIndexed   int
+		repliesIndexed int
+		wg             sync.WaitGroup
+	)
 
 	if len(postsBatch) > 0 {
-		if err := common.BulkIndex(ctx, esClient, "posts", postsBatch, dryRun, logger); err != nil {
-			firstErr = err
-		} else {
-			indexedCount += len(postsBatch)
-		}
-	}
-	if len(repliesBatch) > 0 {
-		if err := common.BulkIndex(ctx, esClient, "replies", repliesBatch, dryRun, logger); err != nil {
-			if firstErr == nil {
-				firstErr = err
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := common.BulkIndex(ctx, esClient, "posts", postsBatch, dryRun, logger); err != nil {
+				logger.Error("[%s] Failed to bulk index posts: %v", batchContext, err)
+			} else {
+				postsIndexed = len(postsBatch)
 			}
-		} else {
-			indexedCount += len(repliesBatch)
-		}
+		}()
 	}
 
-	return indexedCount, firstErr
+	if len(repliesBatch) > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := common.BulkIndex(ctx, esClient, "replies", repliesBatch, dryRun, logger); err != nil {
+				logger.Error("[%s] Failed to bulk index replies: %v", batchContext, err)
+			} else {
+				repliesIndexed = len(repliesBatch)
+			}
+		}()
+	}
+
+	wg.Wait()
+	return postsIndexed + repliesIndexed
 }
 
 // handleAccountDeletion handles account deletion events by querying and deleting all posts and likes

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -654,7 +654,7 @@ func handleAccountDeletion(
 	return nil
 }
 
-// processAccountDocDeletions processes post deletions in batches for account deletion
+// processAccountDocDeletions processes post/reply deletions in batches for account deletion
 func processAccountDocDeletions(
 	ctx context.Context,
 	postAtURIs []string,

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -220,7 +220,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 		ensureIndices := func() error {
 			indexCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			for _, alias := range []string{"posts", "post_tombstones"} {
+			for _, alias := range []string{"posts", "post_tombstones", "replies", "reply_tombstones"} {
 				name := common.CurrentIndexName(alias, config.IndexPeriod)
 				if err := common.EnsureIndex(indexCtx, esClient, name, alias, logger); err != nil {
 					return fmt.Errorf("failed to ensure index for %s: %w", alias, err)
@@ -357,25 +357,29 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				// Flush post deletion batch (tombstones + deletes)
 				if len(tombstoneBatch) > 0 {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					if err := common.BulkIndexPostTombstones(batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-						logger.Error("Failed to bulk index tombstones before account deletion: %v", err)
-					} else {
-						if dryRun {
-							logger.Debug("Dry-run: Would index tombstones before account deletion: %d", len(tombstoneBatch))
+					for _, tombstoneAlias := range []string{"post_tombstones", "reply_tombstones"} {
+						if err := common.BulkIndexPostTombstones(batchCtx, esClient, tombstoneAlias, tombstoneBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk index tombstones to %s before account deletion: %v", tombstoneAlias, err)
 						} else {
-							logger.Debug("Indexed tombstones before account deletion: %d", len(tombstoneBatch))
+							if dryRun {
+								logger.Debug("Dry-run: Would index tombstones to %s before account deletion: %d", tombstoneAlias, len(tombstoneBatch))
+							} else {
+								logger.Debug("Indexed tombstones to %s before account deletion: %d", tombstoneAlias, len(tombstoneBatch))
+							}
 						}
 					}
-					if err := common.BulkDelete(batchCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
-						logger.Error("Failed to bulk delete posts before account deletion: %v", err)
-					} else {
-						deletedCount += len(deleteBatch)
-						if dryRun {
-							logger.Debug("Dry-run: Would delete posts before account deletion: %d", len(deleteBatch))
+					for _, deleteAlias := range []string{"posts", "replies"} {
+						if err := common.BulkDelete(batchCtx, esClient, deleteAlias, deleteBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk delete from %s before account deletion: %v", deleteAlias, err)
 						} else {
-							logger.Debug("Deleted posts before account deletion: %d", len(deleteBatch))
+							if dryRun {
+								logger.Debug("Dry-run: Would delete from %s before account deletion: %d", deleteAlias, len(deleteBatch))
+							} else {
+								logger.Debug("Deleted from %s before account deletion: %d", deleteAlias, len(deleteBatch))
+							}
 						}
 					}
+					deletedCount += len(deleteBatch)
 					tombstoneBatch = tombstoneBatch[:0]
 					deleteBatch = deleteBatch[:0]
 					cancelBatchCtx()
@@ -396,26 +400,30 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 
 				if len(tombstoneBatch) >= batchSize {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					if err := common.BulkIndexPostTombstones(batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-						logger.Error("Failed to bulk index tombstones: %v", err)
-					} else {
-						if dryRun {
-							logger.Debug("Dry-run: Would index %d tombstones", len(tombstoneBatch))
+					for _, tombstoneAlias := range []string{"post_tombstones", "reply_tombstones"} {
+						if err := common.BulkIndexPostTombstones(batchCtx, esClient, tombstoneAlias, tombstoneBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk index tombstones to %s: %v", tombstoneAlias, err)
 						} else {
-							logger.Debug("Indexed %d tombstones", len(tombstoneBatch))
+							if dryRun {
+								logger.Debug("Dry-run: Would index %d tombstones to %s", len(tombstoneBatch), tombstoneAlias)
+							} else {
+								logger.Debug("Indexed %d tombstones to %s", len(tombstoneBatch), tombstoneAlias)
+							}
 						}
 					}
 
-					if err := common.BulkDelete(batchCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
-						logger.Error("Failed to bulk delete posts: %v", err)
-					} else {
-						deletedCount += len(deleteBatch)
-						if dryRun {
-							logger.Debug("Dry-run: Would delete batch: %d posts (total deleted: %d)", len(deleteBatch), deletedCount)
+					for _, deleteAlias := range []string{"posts", "replies"} {
+						if err := common.BulkDelete(batchCtx, esClient, deleteAlias, deleteBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk delete from %s: %v", deleteAlias, err)
 						} else {
-							logger.Debug("Deleted batch: %d posts (total deleted: %d)", len(deleteBatch), deletedCount)
+							if dryRun {
+								logger.Debug("Dry-run: Would delete batch: %d docs from %s (total deleted: %d)", len(deleteBatch), deleteAlias, deletedCount)
+							} else {
+								logger.Debug("Deleted batch: %d docs from %s (total deleted: %d)", len(deleteBatch), deleteAlias, deletedCount)
+							}
 						}
 					}
+					deletedCount += len(deleteBatch)
 
 					tombstoneBatch = tombstoneBatch[:0]
 					deleteBatch = deleteBatch[:0]
@@ -548,26 +556,30 @@ cleanup:
 
 	// Index remaining tombstones and delete posts
 	if len(tombstoneBatch) > 0 {
-		if err := common.BulkIndexPostTombstones(cleanupCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-			logger.Error("Failed to bulk index final tombstone batch: %v", err)
-		} else {
-			if dryRun {
-				logger.Debug("Dry-run: Would index final batch: %d tombstones", len(tombstoneBatch))
+		for _, tombstoneAlias := range []string{"post_tombstones", "reply_tombstones"} {
+			if err := common.BulkIndexPostTombstones(cleanupCtx, esClient, tombstoneAlias, tombstoneBatch, dryRun, logger); err != nil {
+				logger.Error("Failed to bulk index final tombstone batch to %s: %v", tombstoneAlias, err)
 			} else {
-				logger.Debug("Indexed final batch: %d tombstones", len(tombstoneBatch))
+				if dryRun {
+					logger.Debug("Dry-run: Would index final batch: %d tombstones to %s", len(tombstoneBatch), tombstoneAlias)
+				} else {
+					logger.Debug("Indexed final batch: %d tombstones to %s", len(tombstoneBatch), tombstoneAlias)
+				}
 			}
 		}
 
-		if err := common.BulkDelete(cleanupCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
-			logger.Error("Failed to bulk delete final batch: %v", err)
-		} else {
-			deletedCount += len(deleteBatch)
-			if dryRun {
-				logger.Debug("Dry-run: Would delete final batch: %d posts", len(deleteBatch))
+		for _, deleteAlias := range []string{"posts", "replies"} {
+			if err := common.BulkDelete(cleanupCtx, esClient, deleteAlias, deleteBatch, dryRun, logger); err != nil {
+				logger.Error("Failed to bulk delete final batch from %s: %v", deleteAlias, err)
 			} else {
-				logger.Debug("Deleted final batch: %d posts", len(deleteBatch))
+				if dryRun {
+					logger.Debug("Dry-run: Would delete final batch: %d docs from %s", len(deleteBatch), deleteAlias)
+				} else {
+					logger.Debug("Deleted final batch: %d docs from %s", len(deleteBatch), deleteAlias)
+				}
 			}
 		}
+		deletedCount += len(deleteBatch)
 	}
 
 	logger.Info("Spooler ingestion complete. Processed: %d, Deleted: %d, Skipped: %d, Hashtag updates: %d", processedCount, deletedCount, skippedCount, hashtagCount)
@@ -640,18 +652,30 @@ func handleAccountDeletion(
 	}
 	logger.Debug("Found %d posts for account deletion (DID: %s)", len(posts), authorDID)
 
+	// Process post deletions
+	if err := processAccountPostDeletions(ctx, posts, esClient, authorDID, msg.GetTimeUs(), dryRun, logger); err != nil {
+		return fmt.Errorf("failed to process post deletions for account (DID: %s): %w", authorDID, err)
+	}
+	*deletedCount += len(posts)
+
+	// Query replies
+	replies, err := common.QueryPostsByAuthorDID(queryCtx, esClient, "replies", authorDID, logger)
+	if err != nil {
+		return fmt.Errorf("failed to query replies for account deletion (DID: %s): %w", authorDID, err)
+	}
+	logger.Debug("Found %d replies for account deletion (DID: %s)", len(replies), authorDID)
+
+	if err := processAccountPostDeletions(ctx, replies, esClient, authorDID, msg.GetTimeUs(), dryRun, logger); err != nil {
+		return fmt.Errorf("failed to process reply deletions for account (DID: %s): %w", authorDID, err)
+	}
+	*deletedCount += len(replies)
+
 	// Query all likes
 	likes, err := common.QueryLikesByAuthorDID(queryCtx, esClient, "likes", authorDID, logger)
 	if err != nil {
 		return fmt.Errorf("failed to query likes for account deletion (DID: %s): %w", authorDID, err)
 	}
 	logger.Debug("Found %d likes for account deletion (DID: %s)", len(likes), authorDID)
-
-	// Process post deletions
-	if err := processAccountPostDeletions(ctx, posts, esClient, authorDID, msg.GetTimeUs(), dryRun, logger); err != nil {
-		return fmt.Errorf("failed to process post deletions for account (DID: %s): %w", authorDID, err)
-	}
-	*deletedCount += len(posts)
 
 	// Process like deletions
 	if err := processAccountLikeDeletions(ctx, likes, esClient, authorDID, msg.GetTimeUs(), dryRun, logger); err != nil {
@@ -780,14 +804,18 @@ func flushPostDeletionBatch(
 	batchCtx, cancelBatchCtx := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelBatchCtx()
 
-	// Index tombstones first
-	if err := common.BulkIndexPostTombstones(batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-		return fmt.Errorf("failed to bulk index post tombstones: %w", err)
+	// Index tombstones to both post_tombstones and reply_tombstones
+	for _, tombstoneAlias := range []string{"post_tombstones", "reply_tombstones"} {
+		if err := common.BulkIndexPostTombstones(batchCtx, esClient, tombstoneAlias, tombstoneBatch, dryRun, logger); err != nil {
+			return fmt.Errorf("failed to index tombstones to %s: %w", tombstoneAlias, err)
+		}
 	}
 
-	// Then delete posts
-	if err := common.BulkDelete(batchCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
-		return fmt.Errorf("failed to bulk delete posts: %w", err)
+	// Then delete from both posts and replies
+	for _, deleteAlias := range []string{"posts", "replies"} {
+		if err := common.BulkDelete(batchCtx, esClient, deleteAlias, deleteBatch, dryRun, logger); err != nil {
+			return fmt.Errorf("failed to delete from %s: %w", deleteAlias, err)
+		}
 	}
 
 	return nil

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -318,7 +318,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				// Flush post creation batch
 				if len(msgs) > 0 {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					count := indexPosts(batchCtx, msgs, esClient, dryRun, logger, "account deletion flush")
+					count := indexDocuments(batchCtx, msgs, esClient, dryRun, logger, "account deletion flush")
 					processedCount += count
 					// Check if a newer instance has started (every 1000 docs to avoid excessive GCS reads)
 					if processedCount%1000 == 0 {
@@ -488,7 +488,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 
 				if len(msgs) >= batchSize {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					count := indexPosts(batchCtx, msgs, esClient, dryRun, logger, "main batch loop")
+					count := indexDocuments(batchCtx, msgs, esClient, dryRun, logger, "main batch loop")
 					processedCount += count
 					if lastMsg := msgs[len(msgs)-1]; lastMsg.GetTimeUs() > 0 {
 						logger.Metric("freshness_sec", float64(common.CalculateFreshness(lastMsg.GetTimeUs())))
@@ -552,7 +552,7 @@ cleanup:
 
 	// Index remaining documents in batch
 	if len(msgs) > 0 {
-		count := indexPosts(cleanupCtx, msgs, esClient, dryRun, logger, "cleanup")
+		count := indexDocuments(cleanupCtx, msgs, esClient, dryRun, logger, "cleanup")
 		processedCount += count
 		if dryRun {
 			logger.Debug("Dry-run: Would index final batch: %d documents", count)
@@ -649,11 +649,11 @@ func postAliasFromDoc(doc common.ElasticsearchDoc) string {
 	return "posts"
 }
 
-// indexPosts creates Elasticsearch documents from messages and indexes them
-// concurrently — posts and replies are sent to ES in parallel goroutines.
+// indexDocuments creates Elasticsearch documents from messages and indexes them
+// concurrently — posts and replies are routed to their respective indices in parallel goroutines.
 // Like counts start at 0 and are incremented by jetstream when likes arrive.
 // Returns the number of documents successfully indexed.
-func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *elasticsearch.Client, dryRun bool, logger *common.IngestLogger, batchContext string) int {
+func indexDocuments(ctx context.Context, msgs []common.MegaStreamMessage, esClient *elasticsearch.Client, dryRun bool, logger *common.IngestLogger, batchContext string) int {
 	if len(msgs) == 0 {
 		return 0
 	}

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -354,48 +354,12 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
 					var wg sync.WaitGroup
 					wg.Add(2)
-					go func() {
-						defer wg.Done()
-						if err := common.BulkIndexPostTombstones(batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk index tombstones to post_tombstones before account deletion: %v", err)
-						} else if dryRun {
-							logger.Debug("Dry-run: Would index tombstones to post_tombstones before account deletion: %d", len(tombstoneBatch))
-						} else {
-							logger.Debug("Indexed tombstones to post_tombstones before account deletion: %d", len(tombstoneBatch))
-						}
-					}()
-					go func() {
-						defer wg.Done()
-						if err := common.BulkIndexPostTombstones(batchCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk index tombstones to reply_tombstones before account deletion: %v", err)
-						} else if dryRun {
-							logger.Debug("Dry-run: Would index tombstones to reply_tombstones before account deletion: %d", len(tombstoneBatch))
-						} else {
-							logger.Debug("Indexed tombstones to reply_tombstones before account deletion: %d", len(tombstoneBatch))
-						}
-					}()
+					go common.BulkIndexWorker(&wg, batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger, common.BulkIndexPostTombstones, "index tombstones to")
+					go common.BulkIndexWorker(&wg, batchCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger, common.BulkIndexPostTombstones, "index tombstones to")
 					wg.Wait()
 					wg.Add(2)
-					go func() {
-						defer wg.Done()
-						if err := common.BulkDelete(batchCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk delete from posts before account deletion: %v", err)
-						} else if dryRun {
-							logger.Debug("Dry-run: Would delete from posts before account deletion: %d", len(deleteBatch))
-						} else {
-							logger.Debug("Deleted from posts before account deletion: %d", len(deleteBatch))
-						}
-					}()
-					go func() {
-						defer wg.Done()
-						if err := common.BulkDelete(batchCtx, esClient, "replies", deleteBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk delete from replies before account deletion: %v", err)
-						} else if dryRun {
-							logger.Debug("Dry-run: Would delete from replies before account deletion: %d", len(deleteBatch))
-						} else {
-							logger.Debug("Deleted from replies before account deletion: %d", len(deleteBatch))
-						}
-					}()
+					go common.BulkIndexWorker(&wg, batchCtx, esClient, "posts", deleteBatch, dryRun, logger, common.BulkDelete, "delete from")
+					go common.BulkIndexWorker(&wg, batchCtx, esClient, "replies", deleteBatch, dryRun, logger, common.BulkDelete, "delete from")
 					wg.Wait()
 					deletedCount += len(deleteBatch)
 					tombstoneBatch = tombstoneBatch[:0]
@@ -420,48 +384,12 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
 					var wg sync.WaitGroup
 					wg.Add(2)
-					go func() {
-						defer wg.Done()
-						if err := common.BulkIndexPostTombstones(batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk index tombstones to post_tombstones: %v", err)
-						} else if dryRun {
-							logger.Debug("Dry-run: Would index %d tombstones to post_tombstones", len(tombstoneBatch))
-						} else {
-							logger.Debug("Indexed %d tombstones to post_tombstones", len(tombstoneBatch))
-						}
-					}()
-					go func() {
-						defer wg.Done()
-						if err := common.BulkIndexPostTombstones(batchCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk index tombstones to reply_tombstones: %v", err)
-						} else if dryRun {
-							logger.Debug("Dry-run: Would index %d tombstones to reply_tombstones", len(tombstoneBatch))
-						} else {
-							logger.Debug("Indexed %d tombstones to reply_tombstones", len(tombstoneBatch))
-						}
-					}()
+					go common.BulkIndexWorker(&wg, batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger, common.BulkIndexPostTombstones, "index tombstones to")
+					go common.BulkIndexWorker(&wg, batchCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger, common.BulkIndexPostTombstones, "index tombstones to")
 					wg.Wait()
 					wg.Add(2)
-					go func() {
-						defer wg.Done()
-						if err := common.BulkDelete(batchCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk delete from posts: %v", err)
-						} else if dryRun {
-							logger.Debug("Dry-run: Would delete batch: %d docs from posts (total deleted: %d)", len(deleteBatch), deletedCount)
-						} else {
-							logger.Debug("Deleted batch: %d docs from posts (total deleted: %d)", len(deleteBatch), deletedCount)
-						}
-					}()
-					go func() {
-						defer wg.Done()
-						if err := common.BulkDelete(batchCtx, esClient, "replies", deleteBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk delete from replies: %v", err)
-						} else if dryRun {
-							logger.Debug("Dry-run: Would delete batch: %d docs from replies (total deleted: %d)", len(deleteBatch), deletedCount)
-						} else {
-							logger.Debug("Deleted batch: %d docs from replies (total deleted: %d)", len(deleteBatch), deletedCount)
-						}
-					}()
+					go common.BulkIndexWorker(&wg, batchCtx, esClient, "posts", deleteBatch, dryRun, logger, common.BulkDelete, "delete from")
+					go common.BulkIndexWorker(&wg, batchCtx, esClient, "replies", deleteBatch, dryRun, logger, common.BulkDelete, "delete from")
 					wg.Wait()
 					deletedCount += len(deleteBatch)
 
@@ -590,48 +518,12 @@ cleanup:
 	if len(tombstoneBatch) > 0 {
 		var wg sync.WaitGroup
 		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			if err := common.BulkIndexPostTombstones(cleanupCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-				logger.Error("Failed to bulk index final tombstone batch to post_tombstones: %v", err)
-			} else if dryRun {
-				logger.Debug("Dry-run: Would index final batch: %d tombstones to post_tombstones", len(tombstoneBatch))
-			} else {
-				logger.Debug("Indexed final batch: %d tombstones to post_tombstones", len(tombstoneBatch))
-			}
-		}()
-		go func() {
-			defer wg.Done()
-			if err := common.BulkIndexPostTombstones(cleanupCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger); err != nil {
-				logger.Error("Failed to bulk index final tombstone batch to reply_tombstones: %v", err)
-			} else if dryRun {
-				logger.Debug("Dry-run: Would index final batch: %d tombstones to reply_tombstones", len(tombstoneBatch))
-			} else {
-				logger.Debug("Indexed final batch: %d tombstones to reply_tombstones", len(tombstoneBatch))
-			}
-		}()
+		go common.BulkIndexWorker(&wg, cleanupCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger, common.BulkIndexPostTombstones, "index tombstones to")
+		go common.BulkIndexWorker(&wg, cleanupCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger, common.BulkIndexPostTombstones, "index tombstones to")
 		wg.Wait()
 		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			if err := common.BulkDelete(cleanupCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
-				logger.Error("Failed to bulk delete final batch from posts: %v", err)
-			} else if dryRun {
-				logger.Debug("Dry-run: Would delete final batch: %d docs from posts", len(deleteBatch))
-			} else {
-				logger.Debug("Deleted final batch: %d docs from posts", len(deleteBatch))
-			}
-		}()
-		go func() {
-			defer wg.Done()
-			if err := common.BulkDelete(cleanupCtx, esClient, "replies", deleteBatch, dryRun, logger); err != nil {
-				logger.Error("Failed to bulk delete final batch from replies: %v", err)
-			} else if dryRun {
-				logger.Debug("Dry-run: Would delete final batch: %d docs from replies", len(deleteBatch))
-			} else {
-				logger.Debug("Deleted final batch: %d docs from replies", len(deleteBatch))
-			}
-		}()
+		go common.BulkIndexWorker(&wg, cleanupCtx, esClient, "posts", deleteBatch, dryRun, logger, common.BulkDelete, "delete from")
+		go common.BulkIndexWorker(&wg, cleanupCtx, esClient, "replies", deleteBatch, dryRun, logger, common.BulkDelete, "delete from")
 		wg.Wait()
 		deletedCount += len(deleteBatch)
 	}
@@ -728,7 +620,7 @@ func handleAccountDeletion(
 	logger.Debug("Found %d posts for account deletion (DID: %s)", len(posts), authorDID)
 
 	// Process post deletions
-	if err := processAccountPostDeletions(ctx, posts, esClient, authorDID, msg.GetTimeUs(), dryRun, logger); err != nil {
+	if err := processAccountDocDeletions(ctx, posts, esClient, authorDID, msg.GetTimeUs(), dryRun, logger); err != nil {
 		return fmt.Errorf("failed to process post deletions for account (DID: %s): %w", authorDID, err)
 	}
 	*deletedCount += len(posts)
@@ -740,7 +632,7 @@ func handleAccountDeletion(
 	}
 	logger.Debug("Found %d replies for account deletion (DID: %s)", len(replies), authorDID)
 
-	if err := processAccountPostDeletions(ctx, replies, esClient, authorDID, msg.GetTimeUs(), dryRun, logger); err != nil {
+	if err := processAccountDocDeletions(ctx, replies, esClient, authorDID, msg.GetTimeUs(), dryRun, logger); err != nil {
 		return fmt.Errorf("failed to process reply deletions for account (DID: %s): %w", authorDID, err)
 	}
 	*deletedCount += len(replies)
@@ -758,12 +650,12 @@ func handleAccountDeletion(
 	}
 	*deletedCount += len(likes)
 
-	logger.Debug("Completed account deletion for DID: %s (posts: %d, likes: %d)", authorDID, len(posts), len(likes))
+	logger.Debug("Completed account deletion for DID: %s (posts: %d, replies: %d, likes: %d)", authorDID, len(posts), len(replies), len(likes))
 	return nil
 }
 
-// processAccountPostDeletions processes post deletions in batches for account deletion
-func processAccountPostDeletions(
+// processAccountDocDeletions processes post deletions in batches for account deletion
+func processAccountDocDeletions(
 	ctx context.Context,
 	postAtURIs []string,
 	esClient *elasticsearch.Client,

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -320,10 +320,10 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				if len(msgs) > 0 {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
 					count, err := indexPosts(batchCtx, msgs, esClient, dryRun, logger)
+					processedCount += count
 					if err != nil {
 						logger.Error("Failed to index batch before account deletion: %v", err)
 					} else {
-						processedCount += count
 						// Check if a newer instance has started (every 1000 docs to avoid excessive GCS reads)
 						if processedCount%1000 == 0 {
 							if stateManager.CheckForNewerInstance(myStartTime) {
@@ -449,10 +449,10 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				if len(msgs) >= batchSize {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
 					count, err := indexPosts(batchCtx, msgs, esClient, dryRun, logger)
+					processedCount += count
 					if err != nil {
 						logger.Error("Failed to bulk index batch: %v", err)
 					} else {
-						processedCount += count
 						if lastMsg := msgs[len(msgs)-1]; lastMsg.GetTimeUs() > 0 {
 							logger.Metric("freshness_sec", float64(common.CalculateFreshness(lastMsg.GetTimeUs())))
 						}
@@ -517,10 +517,10 @@ cleanup:
 	// Index remaining documents in batch
 	if len(msgs) > 0 {
 		count, err := indexPosts(cleanupCtx, msgs, esClient, dryRun, logger)
+		processedCount += count
 		if err != nil {
 			logger.Error("Failed to bulk index final batch: %v", err)
 		} else {
-			processedCount += count
 			if dryRun {
 				logger.Debug("Dry-run: Would index final batch: %d documents", count)
 			} else {
@@ -620,7 +620,6 @@ func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *
 
 	if len(postsBatch) > 0 {
 		if err := common.BulkIndex(ctx, esClient, "posts", postsBatch, dryRun, logger); err != nil {
-			logger.Error("Failed to bulk index posts: %v", err)
 			firstErr = err
 		} else {
 			indexedCount += len(postsBatch)
@@ -628,7 +627,6 @@ func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *
 	}
 	if len(repliesBatch) > 0 {
 		if err := common.BulkIndex(ctx, esClient, "replies", repliesBatch, dryRun, logger); err != nil {
-			logger.Error("Failed to bulk index replies: %v", err)
 			if firstErr == nil {
 				firstErr = err
 			}

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -574,6 +574,15 @@ cleanup:
 	return nil
 }
 
+// postAliasFromDoc returns the ES alias for a document.
+// Posts with a non-empty thread_parent_post are replies and go to the replies alias.
+func postAliasFromDoc(doc common.ElasticsearchDoc) string {
+	if doc.ThreadParentPost != "" {
+		return "replies"
+	}
+	return "posts"
+}
+
 // indexPosts creates Elasticsearch documents from messages and indexes them
 // Like counts start at 0 and are incremented by jetstream when likes arrive
 // Returns the number of documents indexed
@@ -582,17 +591,30 @@ func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *
 		return 0, nil
 	}
 
-	batch := make([]common.ElasticsearchDoc, 0, len(msgs))
+	postsBatch := make([]common.ElasticsearchDoc, 0, len(msgs))
+	repliesBatch := make([]common.ElasticsearchDoc, 0)
+
 	for _, m := range msgs {
 		doc := common.CreateElasticsearchDoc(m, 0)
-		batch = append(batch, doc)
+		if postAliasFromDoc(doc) == "replies" {
+			repliesBatch = append(repliesBatch, doc)
+		} else {
+			postsBatch = append(postsBatch, doc)
+		}
 	}
 
-	if err := common.BulkIndex(ctx, esClient, "posts", batch, dryRun, logger); err != nil {
-		return 0, fmt.Errorf("failed to bulk index batch: %w", err)
+	if len(postsBatch) > 0 {
+		if err := common.BulkIndex(ctx, esClient, "posts", postsBatch, dryRun, logger); err != nil {
+			return 0, fmt.Errorf("failed to bulk index posts: %w", err)
+		}
+	}
+	if len(repliesBatch) > 0 {
+		if err := common.BulkIndex(ctx, esClient, "replies", repliesBatch, dryRun, logger); err != nil {
+			return 0, fmt.Errorf("failed to bulk index replies: %w", err)
+		}
 	}
 
-	return len(batch), nil
+	return len(postsBatch) + len(repliesBatch), nil
 }
 
 // handleAccountDeletion handles account deletion events by querying and deleting all posts and likes

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -21,8 +21,6 @@ import (
 	"github.com/greenearth/ingest/internal/megastream_ingest"
 )
 
-// TODO: Move to multithreaded implementation
-
 func main() {
 	// Parse command line flags
 	dryRun := flag.Bool("dry-run", false, "Run in dry-run mode (no writes to Elasticsearch)")

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -615,18 +615,29 @@ func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *
 		}
 	}
 
+	indexedCount := 0
+	var firstErr error
+
 	if len(postsBatch) > 0 {
 		if err := common.BulkIndex(ctx, esClient, "posts", postsBatch, dryRun, logger); err != nil {
-			return 0, fmt.Errorf("failed to bulk index posts: %w", err)
+			logger.Error("Failed to bulk index posts: %v", err)
+			firstErr = err
+		} else {
+			indexedCount += len(postsBatch)
 		}
 	}
 	if len(repliesBatch) > 0 {
 		if err := common.BulkIndex(ctx, esClient, "replies", repliesBatch, dryRun, logger); err != nil {
-			return 0, fmt.Errorf("failed to bulk index replies: %w", err)
+			logger.Error("Failed to bulk index replies: %v", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		} else {
+			indexedCount += len(repliesBatch)
 		}
 	}
 
-	return len(postsBatch) + len(repliesBatch), nil
+	return indexedCount, firstErr
 }
 
 // handleAccountDeletion handles account deletion events by querying and deleting all posts and likes

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -354,28 +354,51 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				// Flush post deletion batch (tombstones + deletes)
 				if len(tombstoneBatch) > 0 {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					for _, tombstoneAlias := range []string{"post_tombstones", "reply_tombstones"} {
-						if err := common.BulkIndexPostTombstones(batchCtx, esClient, tombstoneAlias, tombstoneBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk index tombstones to %s before account deletion: %v", tombstoneAlias, err)
+					var wg sync.WaitGroup
+					wg.Add(2)
+					go func() {
+						defer wg.Done()
+						if err := common.BulkIndexPostTombstones(batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk index tombstones to post_tombstones before account deletion: %v", err)
+						} else if dryRun {
+							logger.Debug("Dry-run: Would index tombstones to post_tombstones before account deletion: %d", len(tombstoneBatch))
 						} else {
-							if dryRun {
-								logger.Debug("Dry-run: Would index tombstones to %s before account deletion: %d", tombstoneAlias, len(tombstoneBatch))
-							} else {
-								logger.Debug("Indexed tombstones to %s before account deletion: %d", tombstoneAlias, len(tombstoneBatch))
-							}
+							logger.Debug("Indexed tombstones to post_tombstones before account deletion: %d", len(tombstoneBatch))
 						}
-					}
-					for _, deleteAlias := range []string{"posts", "replies"} {
-						if err := common.BulkDelete(batchCtx, esClient, deleteAlias, deleteBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk delete from %s before account deletion: %v", deleteAlias, err)
+					}()
+					go func() {
+						defer wg.Done()
+						if err := common.BulkIndexPostTombstones(batchCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk index tombstones to reply_tombstones before account deletion: %v", err)
+						} else if dryRun {
+							logger.Debug("Dry-run: Would index tombstones to reply_tombstones before account deletion: %d", len(tombstoneBatch))
 						} else {
-							if dryRun {
-								logger.Debug("Dry-run: Would delete from %s before account deletion: %d", deleteAlias, len(deleteBatch))
-							} else {
-								logger.Debug("Deleted from %s before account deletion: %d", deleteAlias, len(deleteBatch))
-							}
+							logger.Debug("Indexed tombstones to reply_tombstones before account deletion: %d", len(tombstoneBatch))
 						}
-					}
+					}()
+					wg.Wait()
+					wg.Add(2)
+					go func() {
+						defer wg.Done()
+						if err := common.BulkDelete(batchCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk delete from posts before account deletion: %v", err)
+						} else if dryRun {
+							logger.Debug("Dry-run: Would delete from posts before account deletion: %d", len(deleteBatch))
+						} else {
+							logger.Debug("Deleted from posts before account deletion: %d", len(deleteBatch))
+						}
+					}()
+					go func() {
+						defer wg.Done()
+						if err := common.BulkDelete(batchCtx, esClient, "replies", deleteBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk delete from replies before account deletion: %v", err)
+						} else if dryRun {
+							logger.Debug("Dry-run: Would delete from replies before account deletion: %d", len(deleteBatch))
+						} else {
+							logger.Debug("Deleted from replies before account deletion: %d", len(deleteBatch))
+						}
+					}()
+					wg.Wait()
 					deletedCount += len(deleteBatch)
 					tombstoneBatch = tombstoneBatch[:0]
 					deleteBatch = deleteBatch[:0]
@@ -397,29 +420,51 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 
 				if len(tombstoneBatch) >= batchSize {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					for _, tombstoneAlias := range []string{"post_tombstones", "reply_tombstones"} {
-						if err := common.BulkIndexPostTombstones(batchCtx, esClient, tombstoneAlias, tombstoneBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk index tombstones to %s: %v", tombstoneAlias, err)
+					var wg sync.WaitGroup
+					wg.Add(2)
+					go func() {
+						defer wg.Done()
+						if err := common.BulkIndexPostTombstones(batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk index tombstones to post_tombstones: %v", err)
+						} else if dryRun {
+							logger.Debug("Dry-run: Would index %d tombstones to post_tombstones", len(tombstoneBatch))
 						} else {
-							if dryRun {
-								logger.Debug("Dry-run: Would index %d tombstones to %s", len(tombstoneBatch), tombstoneAlias)
-							} else {
-								logger.Debug("Indexed %d tombstones to %s", len(tombstoneBatch), tombstoneAlias)
-							}
+							logger.Debug("Indexed %d tombstones to post_tombstones", len(tombstoneBatch))
 						}
-					}
-
-					for _, deleteAlias := range []string{"posts", "replies"} {
-						if err := common.BulkDelete(batchCtx, esClient, deleteAlias, deleteBatch, dryRun, logger); err != nil {
-							logger.Error("Failed to bulk delete from %s: %v", deleteAlias, err)
+					}()
+					go func() {
+						defer wg.Done()
+						if err := common.BulkIndexPostTombstones(batchCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk index tombstones to reply_tombstones: %v", err)
+						} else if dryRun {
+							logger.Debug("Dry-run: Would index %d tombstones to reply_tombstones", len(tombstoneBatch))
 						} else {
-							if dryRun {
-								logger.Debug("Dry-run: Would delete batch: %d docs from %s (total deleted: %d)", len(deleteBatch), deleteAlias, deletedCount)
-							} else {
-								logger.Debug("Deleted batch: %d docs from %s (total deleted: %d)", len(deleteBatch), deleteAlias, deletedCount)
-							}
+							logger.Debug("Indexed %d tombstones to reply_tombstones", len(tombstoneBatch))
 						}
-					}
+					}()
+					wg.Wait()
+					wg.Add(2)
+					go func() {
+						defer wg.Done()
+						if err := common.BulkDelete(batchCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk delete from posts: %v", err)
+						} else if dryRun {
+							logger.Debug("Dry-run: Would delete batch: %d docs from posts (total deleted: %d)", len(deleteBatch), deletedCount)
+						} else {
+							logger.Debug("Deleted batch: %d docs from posts (total deleted: %d)", len(deleteBatch), deletedCount)
+						}
+					}()
+					go func() {
+						defer wg.Done()
+						if err := common.BulkDelete(batchCtx, esClient, "replies", deleteBatch, dryRun, logger); err != nil {
+							logger.Error("Failed to bulk delete from replies: %v", err)
+						} else if dryRun {
+							logger.Debug("Dry-run: Would delete batch: %d docs from replies (total deleted: %d)", len(deleteBatch), deletedCount)
+						} else {
+							logger.Debug("Deleted batch: %d docs from replies (total deleted: %d)", len(deleteBatch), deletedCount)
+						}
+					}()
+					wg.Wait()
 					deletedCount += len(deleteBatch)
 
 					tombstoneBatch = tombstoneBatch[:0]
@@ -545,29 +590,51 @@ cleanup:
 
 	// Index remaining tombstones and delete posts
 	if len(tombstoneBatch) > 0 {
-		for _, tombstoneAlias := range []string{"post_tombstones", "reply_tombstones"} {
-			if err := common.BulkIndexPostTombstones(cleanupCtx, esClient, tombstoneAlias, tombstoneBatch, dryRun, logger); err != nil {
-				logger.Error("Failed to bulk index final tombstone batch to %s: %v", tombstoneAlias, err)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := common.BulkIndexPostTombstones(cleanupCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger); err != nil {
+				logger.Error("Failed to bulk index final tombstone batch to post_tombstones: %v", err)
+			} else if dryRun {
+				logger.Debug("Dry-run: Would index final batch: %d tombstones to post_tombstones", len(tombstoneBatch))
 			} else {
-				if dryRun {
-					logger.Debug("Dry-run: Would index final batch: %d tombstones to %s", len(tombstoneBatch), tombstoneAlias)
-				} else {
-					logger.Debug("Indexed final batch: %d tombstones to %s", len(tombstoneBatch), tombstoneAlias)
-				}
+				logger.Debug("Indexed final batch: %d tombstones to post_tombstones", len(tombstoneBatch))
 			}
-		}
-
-		for _, deleteAlias := range []string{"posts", "replies"} {
-			if err := common.BulkDelete(cleanupCtx, esClient, deleteAlias, deleteBatch, dryRun, logger); err != nil {
-				logger.Error("Failed to bulk delete final batch from %s: %v", deleteAlias, err)
+		}()
+		go func() {
+			defer wg.Done()
+			if err := common.BulkIndexPostTombstones(cleanupCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger); err != nil {
+				logger.Error("Failed to bulk index final tombstone batch to reply_tombstones: %v", err)
+			} else if dryRun {
+				logger.Debug("Dry-run: Would index final batch: %d tombstones to reply_tombstones", len(tombstoneBatch))
 			} else {
-				if dryRun {
-					logger.Debug("Dry-run: Would delete final batch: %d docs from %s", len(deleteBatch), deleteAlias)
-				} else {
-					logger.Debug("Deleted final batch: %d docs from %s", len(deleteBatch), deleteAlias)
-				}
+				logger.Debug("Indexed final batch: %d tombstones to reply_tombstones", len(tombstoneBatch))
 			}
-		}
+		}()
+		wg.Wait()
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := common.BulkDelete(cleanupCtx, esClient, "posts", deleteBatch, dryRun, logger); err != nil {
+				logger.Error("Failed to bulk delete final batch from posts: %v", err)
+			} else if dryRun {
+				logger.Debug("Dry-run: Would delete final batch: %d docs from posts", len(deleteBatch))
+			} else {
+				logger.Debug("Deleted final batch: %d docs from posts", len(deleteBatch))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if err := common.BulkDelete(cleanupCtx, esClient, "replies", deleteBatch, dryRun, logger); err != nil {
+				logger.Error("Failed to bulk delete final batch from replies: %v", err)
+			} else if dryRun {
+				logger.Debug("Dry-run: Would delete final batch: %d docs from replies", len(deleteBatch))
+			} else {
+				logger.Debug("Deleted final batch: %d docs from replies", len(deleteBatch))
+			}
+		}()
+		wg.Wait()
 		deletedCount += len(deleteBatch)
 	}
 
@@ -815,17 +882,42 @@ func flushPostDeletionBatch(
 	defer cancelBatchCtx()
 
 	// Index tombstones to both post_tombstones and reply_tombstones
-	for _, tombstoneAlias := range []string{"post_tombstones", "reply_tombstones"} {
-		if err := common.BulkIndexPostTombstones(batchCtx, esClient, tombstoneAlias, tombstoneBatch, dryRun, logger); err != nil {
-			return fmt.Errorf("failed to index tombstones to %s: %w", tombstoneAlias, err)
-		}
+	var postTombstoneErr, replyTombstoneErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		postTombstoneErr = common.BulkIndexPostTombstones(batchCtx, esClient, "post_tombstones", tombstoneBatch, dryRun, logger)
+	}()
+	go func() {
+		defer wg.Done()
+		replyTombstoneErr = common.BulkIndexPostTombstones(batchCtx, esClient, "reply_tombstones", tombstoneBatch, dryRun, logger)
+	}()
+	wg.Wait()
+	if postTombstoneErr != nil {
+		return fmt.Errorf("failed to index tombstones to post_tombstones: %w", postTombstoneErr)
+	}
+	if replyTombstoneErr != nil {
+		return fmt.Errorf("failed to index tombstones to reply_tombstones: %w", replyTombstoneErr)
 	}
 
 	// Then delete from both posts and replies
-	for _, deleteAlias := range []string{"posts", "replies"} {
-		if err := common.BulkDelete(batchCtx, esClient, deleteAlias, deleteBatch, dryRun, logger); err != nil {
-			return fmt.Errorf("failed to delete from %s: %w", deleteAlias, err)
-		}
+	var postsDeleteErr, repliesDeleteErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		postsDeleteErr = common.BulkDelete(batchCtx, esClient, "posts", deleteBatch, dryRun, logger)
+	}()
+	go func() {
+		defer wg.Done()
+		repliesDeleteErr = common.BulkDelete(batchCtx, esClient, "replies", deleteBatch, dryRun, logger)
+	}()
+	wg.Wait()
+	if postsDeleteErr != nil {
+		return fmt.Errorf("failed to delete from posts: %w", postsDeleteErr)
+	}
+	if repliesDeleteErr != nil {
+		return fmt.Errorf("failed to delete from replies: %w", repliesDeleteErr)
 	}
 
 	return nil

--- a/ingest/cmd/megastream_ingest/main_test.go
+++ b/ingest/cmd/megastream_ingest/main_test.go
@@ -21,15 +21,15 @@ func TestPostAliasFromDoc_reply(t *testing.T) {
 }
 
 // TestIndexPosts_errorHandlingContract documents the intended behavior of indexPosts:
-// - If posts indexing fails, replies indexing is still attempted.
+// - posts and replies are indexed concurrently via goroutines.
+// - If either batch fails, the error is logged internally with batchContext; no error is returned.
 // - The returned count reflects only successfully indexed documents.
-// - An error is returned only if both batches fail (or the only non-empty batch fails).
 //
 // Full integration testing requires a live ES instance; this contract is enforced
 // by the implementation in indexPosts and verified via code review.
 func TestIndexPosts_errorHandlingContract(t *testing.T) {
 	// Verified by implementation: see indexPosts in main.go
-	// posts and replies are indexed independently; failure in one does not
-	// prevent the other from being attempted.
+	// posts and replies are indexed concurrently; failure in one does not
+	// prevent the other from being attempted, and does not block the caller.
 	t.Log("contract documented; see indexPosts implementation")
 }

--- a/ingest/cmd/megastream_ingest/main_test.go
+++ b/ingest/cmd/megastream_ingest/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/greenearth/ingest/internal/common"
+)
+
+func TestPostAliasFromDoc_originalPost(t *testing.T) {
+	doc := common.ElasticsearchDoc{ThreadParentPost: ""}
+	if got := postAliasFromDoc(doc); got != "posts" {
+		t.Errorf("expected posts, got %s", got)
+	}
+}
+
+func TestPostAliasFromDoc_reply(t *testing.T) {
+	doc := common.ElasticsearchDoc{ThreadParentPost: "at://did:plc:abc/app.bsky.feed.post/xyz"}
+	if got := postAliasFromDoc(doc); got != "replies" {
+		t.Errorf("expected replies, got %s", got)
+	}
+}

--- a/ingest/cmd/megastream_ingest/main_test.go
+++ b/ingest/cmd/megastream_ingest/main_test.go
@@ -20,16 +20,16 @@ func TestPostAliasFromDoc_reply(t *testing.T) {
 	}
 }
 
-// TestIndexPosts_errorHandlingContract documents the intended behavior of indexPosts:
+// TestIndexDocuments_errorHandlingContract documents the intended behavior of indexDocuments:
 // - posts and replies are indexed concurrently via goroutines.
 // - If either batch fails, the error is logged internally with batchContext; no error is returned.
 // - The returned count reflects only successfully indexed documents.
 //
 // Full integration testing requires a live ES instance; this contract is enforced
-// by the implementation in indexPosts and verified via code review.
-func TestIndexPosts_errorHandlingContract(t *testing.T) {
-	// Verified by implementation: see indexPosts in main.go
+// by the implementation in indexDocuments and verified via code review.
+func TestIndexDocuments_errorHandlingContract(t *testing.T) {
+	// Verified by implementation: see indexDocuments in main.go
 	// posts and replies are indexed concurrently; failure in one does not
 	// prevent the other from being attempted, and does not block the caller.
-	t.Log("contract documented; see indexPosts implementation")
+	t.Log("contract documented; see indexDocuments implementation")
 }

--- a/ingest/cmd/megastream_ingest/main_test.go
+++ b/ingest/cmd/megastream_ingest/main_test.go
@@ -19,3 +19,17 @@ func TestPostAliasFromDoc_reply(t *testing.T) {
 		t.Errorf("expected replies, got %s", got)
 	}
 }
+
+// TestIndexPosts_errorHandlingContract documents the intended behavior of indexPosts:
+// - If posts indexing fails, replies indexing is still attempted.
+// - The returned count reflects only successfully indexed documents.
+// - An error is returned only if both batches fail (or the only non-empty batch fails).
+//
+// Full integration testing requires a live ES instance; this contract is enforced
+// by the implementation in indexPosts and verified via code review.
+func TestIndexPosts_errorHandlingContract(t *testing.T) {
+	// Verified by implementation: see indexPosts in main.go
+	// posts and replies are indexed independently; failure in one does not
+	// prevent the other from being attempted.
+	t.Log("contract documented; see indexPosts implementation")
+}

--- a/ingest/internal/common/bulk_worker.go
+++ b/ingest/internal/common/bulk_worker.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"context"
+	"sync"
+
+	"github.com/elastic/go-elasticsearch/v9"
+)
+
+// BulkIndexWorker wraps a bulk ES operation for concurrent use.
+// Must be launched with `go` after wg.Add(1). Logs the outcome; errors are
+// not returned — callers that need error propagation should use direct calls.
+func BulkIndexWorker[T any](
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	esClient *elasticsearch.Client,
+	indexName string,
+	batch []T,
+	dryRun bool,
+	logger *IngestLogger,
+	fn func(context.Context, *elasticsearch.Client, string, []T, bool, *IngestLogger) error,
+	action string,
+) {
+	defer wg.Done()
+	if err := fn(ctx, esClient, indexName, batch, dryRun, logger); err != nil {
+		logger.Error("Failed to %s %s: %v", action, indexName, err)
+	} else if dryRun {
+		logger.Debug("Dry-run: Would %s %d docs to %s", action, len(batch), indexName)
+	} else {
+		logger.Debug("%s %d docs to %s", action, len(batch), indexName)
+	}
+}

--- a/ingest/internal/common/bulk_worker_test.go
+++ b/ingest/internal/common/bulk_worker_test.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v9"
+)
+
+func TestBulkIndexWorker_callsFn(t *testing.T) {
+	called := false
+	fn := func(_ context.Context, _ *elasticsearch.Client, _ string, _ []string, _ bool, _ *IngestLogger) error {
+		called = true
+		return nil
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go BulkIndexWorker(&wg, context.Background(), nil, "test-index", []string{"a", "b"}, false, NewLogger(false), fn, "index")
+	wg.Wait()
+	if !called {
+		t.Fatal("fn was not called")
+	}
+}
+
+func TestBulkIndexWorker_errorIsLogged(t *testing.T) {
+	fn := func(_ context.Context, _ *elasticsearch.Client, _ string, _ []string, _ bool, _ *IngestLogger) error {
+		return fmt.Errorf("intentional error")
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go BulkIndexWorker(&wg, context.Background(), nil, "test-index", []string{"a"}, false, NewLogger(false), fn, "index")
+	wg.Wait()
+	// passes if no panic — error is logged, not propagated
+}
+
+func TestBulkIndexWorker_dryRunPassedToFn(t *testing.T) {
+	var gotDryRun bool
+	fn := func(_ context.Context, _ *elasticsearch.Client, _ string, _ []string, dryRun bool, _ *IngestLogger) error {
+		gotDryRun = dryRun
+		return nil
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go BulkIndexWorker(&wg, context.Background(), nil, "test-index", []string{"a"}, true, NewLogger(false), fn, "index")
+	wg.Wait()
+	if !gotDryRun {
+		t.Fatal("dryRun=true was not passed to fn")
+	}
+}

--- a/ingest/internal/common/elasticsearch.go
+++ b/ingest/internal/common/elasticsearch.go
@@ -1423,9 +1423,9 @@ func aggregateLikeCountUpdates(updates []LikeCountUpdate) map[string]int {
 	return aggregated
 }
 
-// BulkUpdatePostLikeCounts updates like_count fields on posts using the ES update API
+// BulkUpdateLikeCounts updates like_count fields on documents using the ES update API.
 // Routes each update to the correct shard by extracting the author DID from the AT-URI.
-func BulkUpdatePostLikeCounts(ctx context.Context, client *elasticsearch.Client, index string, updates []LikeCountUpdate, dryRun bool, logger *IngestLogger) error {
+func BulkUpdateLikeCounts(ctx context.Context, client *elasticsearch.Client, index string, updates []LikeCountUpdate, dryRun bool, logger *IngestLogger) error {
 	if len(updates) == 0 {
 		return nil
 	}

--- a/ingest/internal/common/elasticsearch_like_count_test.go
+++ b/ingest/internal/common/elasticsearch_like_count_test.go
@@ -146,7 +146,7 @@ func TestExtractDIDFromATURI(t *testing.T) {
 	}
 }
 
-func TestBulkUpdatePostLikeCounts_DryRun(t *testing.T) {
+func TestBulkUpdateLikeCounts_DryRun(t *testing.T) {
 	logger := NewLogger(false)
 
 	updates := []LikeCountUpdate{
@@ -154,29 +154,29 @@ func TestBulkUpdatePostLikeCounts_DryRun(t *testing.T) {
 	}
 
 	// Dry-run should not error with nil client
-	err := BulkUpdatePostLikeCounts(context.TODO(), nil, "posts", updates, true, logger)
+	err := BulkUpdateLikeCounts(context.TODO(), nil, "posts", updates, true, logger)
 	if err != nil {
 		t.Errorf("Expected no error in dry-run mode, got: %v", err)
 	}
 }
 
-func TestBulkUpdatePostLikeCounts_EmptyBatch(t *testing.T) {
+func TestBulkUpdateLikeCounts_EmptyBatch(t *testing.T) {
 	logger := NewLogger(false)
 
 	// Empty batch should not error
-	err := BulkUpdatePostLikeCounts(context.TODO(), nil, "posts", []LikeCountUpdate{}, false, logger)
+	err := BulkUpdateLikeCounts(context.TODO(), nil, "posts", []LikeCountUpdate{}, false, logger)
 	if err != nil {
 		t.Errorf("Expected no error for empty batch, got: %v", err)
 	}
 
 	// Nil batch should not error
-	err2 := BulkUpdatePostLikeCounts(context.TODO(), nil, "posts", nil, false, logger)
+	err2 := BulkUpdateLikeCounts(context.TODO(), nil, "posts", nil, false, logger)
 	if err2 != nil {
 		t.Errorf("Expected no error for nil batch, got: %v", err2)
 	}
 }
 
-func TestBulkUpdatePostLikeCounts_EmptySubjectURI(t *testing.T) {
+func TestBulkUpdateLikeCounts_EmptySubjectURI(t *testing.T) {
 	logger := NewLogger(false)
 
 	updates := []LikeCountUpdate{
@@ -185,7 +185,7 @@ func TestBulkUpdatePostLikeCounts_EmptySubjectURI(t *testing.T) {
 	}
 
 	// Should return error when all updates have empty subject_uri
-	err := BulkUpdatePostLikeCounts(context.TODO(), nil, "posts", updates, false, logger)
+	err := BulkUpdateLikeCounts(context.TODO(), nil, "posts", updates, false, logger)
 	if err == nil {
 		t.Error("Expected error when all updates have empty subject_uri")
 	}
@@ -195,7 +195,7 @@ func TestBulkUpdatePostLikeCounts_EmptySubjectURI(t *testing.T) {
 	}
 }
 
-func TestBulkUpdatePostLikeCounts_MixedEmptyAndValid(t *testing.T) {
+func TestBulkUpdateLikeCounts_MixedEmptyAndValid(t *testing.T) {
 	updates := []LikeCountUpdate{
 		{SubjectURI: "", Increment: 1},
 		{SubjectURI: "at://valid", Increment: 1},

--- a/ingest/scripts/deploy.sh
+++ b/ingest/scripts/deploy.sh
@@ -388,13 +388,11 @@ deploy_extract_job() {
     # Set extraction parameters based on environment
     local max_records
     local window_minutes
-    local indices
     local destination_bucket
 
     max_records=1000000      # 1M records
     window_minutes=33       # ~1/2 hour
-    indices="posts,likes,hashtags,replies"
-    log_info "$GE_ENVIRONMENT environment: 1M max records, approx. 30 min window, indices: posts,likes,hashtags"
+    log_info "$GE_ENVIRONMENT environment: 1M max records, approx. 30 min window, indices: posts,likes,hashtags,replies"
     destination_bucket="$GE_GCP_PROJECT_ID-ingex-extract-$GE_ENVIRONMENT"
 
     # Prepare source directory (similar to expiry job)

--- a/ingest/scripts/deploy.sh
+++ b/ingest/scripts/deploy.sh
@@ -393,7 +393,7 @@ deploy_extract_job() {
 
     max_records=1000000      # 1M records
     window_minutes=33       # ~1/2 hour
-    indices="posts,likes,hashtags"
+    indices="posts,likes,hashtags,replies"
     log_info "$GE_ENVIRONMENT environment: 1M max records, approx. 30 min window, indices: posts,likes,hashtags"
     destination_bucket="$GE_GCP_PROJECT_ID-ingex-extract-$GE_ENVIRONMENT"
 
@@ -420,7 +420,7 @@ deploy_extract_job() {
         --set-secrets="GE_ELASTICSEARCH_API_KEY=$es_api_key_secret:latest" \
         --set-env-vars="GE_LOGGING_ENABLED=true" \
         --set-env-vars="GE_GIT_SHA=$GIT_SHA" \
-        --set-env-vars="^|^GE_EXTRACT_INDICES=posts,likes,hashtags" \
+        --set-env-vars="^|^GE_EXTRACT_INDICES=posts,likes,hashtags,replies" \
         --set-env-vars="GE_PARQUET_DESTINATION=gs://$destination_bucket" \
         --set-env-vars="GE_PARQUET_MAX_RECORDS=$max_records" \
         --set-env-vars="GE_GCP_PROJECT_ID=$GE_GCP_PROJECT_ID" \

--- a/ingest/scripts/k8s_recreate_api_keys.sh
+++ b/ingest/scripts/k8s_recreate_api_keys.sh
@@ -67,6 +67,8 @@ INGEST_KEY_RESPONSE=$(kubectl exec -n "${GE_K8S_NAMESPACE}" "${ES_POD}" -- curl 
             "names": ["posts*", "likes*",
               "post_tombstones", "post_tombstones_*", "post-tombstones-*",
               "like_tombstones", "like_tombstones_*", "like-tombstones-*",
+              "replies", "replies-*",
+              "reply_tombstones", "reply_tombstones_*", "reply-tombstones-*",
               "hashtags", "hashtags*", "inferences", "inferences-*"],
             "privileges": ["all", "maintenance", "create_index", "auto_configure"]
           }


### PR DESCRIPTION
## Summary

- Adds dedicated `replies` and `reply-tombstones` Elasticsearch indices (closes #359)
- Megastream routes posts with `thread_parent_post != ""` to `replies` alias instead of `posts`
- Delete events dual-write to both `posts`+`replies` and both tombstone aliases (at delete-time `thread_parent_post` is unavailable, so we can't route — ES no-ops the miss)
- Jetstream like count updates dual-write to `posts`+`replies` for the same reason
- Account deletion extended to query and delete from `replies` alias
- `extract` binary gains `IndexTypeReplies`; deploy script `GE_EXTRACT_INDICES` updated to include `replies`

## Migration (post-merge, run after prod deployment)

See issue #359 for the `_reindex` + `_delete_by_query` steps to backfill existing replies from `posts` into `replies`.

## Test Plan

- [x] Unit tests pass: `TestPostAliasFromDoc_*`, `TestParseIndexType_replies`, `TestGenerateFilename_replies`
- [x] `go test ./... -short` passes
- [x] Local ES: `replies_ilm_policy` and `replies_ilm_template` created via bootstrap job
- [x] Local ES: megastream `EnsureIndex` creates `replies` and `reply_tombstones` write indices
- [x] Stage ES: schema deployed — `replies_ilm_policy`, `replies_ilm_template`, `reply_tombstones_ilm_template` created
- [x] Stage: megastream + jetstream (+ extract) redeploy
- [x] Stage: Kibana verification

## Kibana Screenshot
<img width="1920" height="825" alt="image" src="https://github.com/user-attachments/assets/23c36daf-fdc8-47fe-b76e-cc765c15e66a" />
The attached Kibana dashboard shows that the `replies-\*` index is now being ingested correctly as a separate index.

## Next Steps
- [ ] Prod deployment
- [ ] Replies migration