### PR TITLE
Add GCP IAM permission check script

### DIFF
--- a/tools/check_gcp_permissions.sh
+++ b/tools/check_gcp_permissions.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-# Check whether the current gcloud identity has the IAM permissions needed to
-# run index/deploy.sh and ingest/scripts/deploy.sh.
+# Print the GCP IAM permissions the current gcloud identity has on the
+# project that are relevant to running index/deploy.sh and
+# ingest/scripts/deploy.sh. Output is a sorted, one-per-line list of granted
+# permissions with no other noise, so two runs (e.g. yours and a teammate's)
+# can be diffed directly:
+#
+#   ./check_gcp_permissions.sh > me.txt
+#   ./check_gcp_permissions.sh > teammate.txt   # run by the teammate
+#   diff me.txt teammate.txt
 #
 # There is no `gcloud projects test-iam-permissions` command, so this calls
 # the Cloud Resource Manager `testIamPermissions` API directly via curl using
@@ -11,57 +18,54 @@
 
 set -e
 
-echo "=== Identity & Project ==="
-gcloud auth list
-gcloud config get-value project
-PROJECT=$(gcloud config get-value project)
-TOKEN=$(gcloud auth print-access-token)
+PROJECT=$(gcloud config get-value project 2>/dev/null)
+TOKEN=$(gcloud auth print-access-token 2>/dev/null)
 
-# Prints only the permissions from $1 (comma-separated) that the current
-# identity actually has on the project; anything missing from the response
-# is a permission they lack.
-test_permissions() {
-    local label="$1"
-    local permissions="$2"
-    local json_permissions
-    json_permissions=$(echo "$permissions" | sed 's/,/", "/g')
+PERMISSIONS=$(cat <<'EOF' | paste -sd, -
+container.clusters.get
+container.clusters.create
+container.clusters.getCredentials
+container.clusters.list
+run.services.create
+run.services.update
+run.services.get
+run.jobs.create
+run.jobs.update
+run.jobs.run
+cloudbuild.builds.create
+cloudbuild.builds.get
+cloudbuild.builds.list
+artifactregistry.repositories.uploadArtifacts
+artifactregistry.repositories.downloadArtifacts
+artifactregistry.repositories.get
+secretmanager.secrets.create
+secretmanager.versions.add
+secretmanager.versions.access
+secretmanager.secrets.get
+storage.buckets.get
+storage.buckets.create
+storage.objects.create
+storage.objects.get
+storage.objects.list
+vpcaccess.connectors.create
+vpcaccess.connectors.get
+vpcaccess.connectors.use
+iam.serviceAccounts.actAs
+iam.serviceAccounts.get
+iam.serviceAccounts.create
+iam.serviceAccounts.setIamPolicy
+monitoring.timeSeries.create
+monitoring.metricDescriptors.create
+serviceusage.services.enable
+serviceusage.services.get
+EOF
+)
 
-    echo ""
-    echo "=== $label ==="
-    curl -s -X POST \
-        -H "Authorization: Bearer $TOKEN" \
-        -H "Content-Type: application/json" \
-        -d "{\"permissions\": [\"$json_permissions\"]}" \
-        "https://cloudresourcemanager.googleapis.com/v1/projects/${PROJECT}:testIamPermissions"
-    echo ""
-}
+json_permissions=$(echo "$PERMISSIONS" | sed 's/,/", "/g')
 
-test_permissions "GKE (index/deploy.sh: cluster create/access)" \
-  "container.clusters.get,container.clusters.create,container.clusters.getCredentials,container.clusters.list"
-
-test_permissions "Cloud Run (ingest/scripts/deploy.sh: deploy services & jobs)" \
-  "run.services.create,run.services.update,run.services.get,run.jobs.create,run.jobs.update,run.jobs.run"
-
-test_permissions "Cloud Build (triggered by 'gcloud run deploy --source=.')" \
-  "cloudbuild.builds.create,cloudbuild.builds.get,cloudbuild.builds.list"
-
-test_permissions "Artifact Registry (image push during source-based deploy)" \
-  "artifactregistry.repositories.uploadArtifacts,artifactregistry.repositories.downloadArtifacts,artifactregistry.repositories.get"
-
-test_permissions "Secret Manager (env var injection: ES API key, AWS keys)" \
-  "secretmanager.secrets.create,secretmanager.versions.add,secretmanager.versions.access,secretmanager.secrets.get"
-
-test_permissions "Cloud Storage (state files, parquet export, blocklist, ES snapshots)" \
-  "storage.buckets.get,storage.buckets.create,storage.objects.create,storage.objects.get,storage.objects.list"
-
-test_permissions "VPC Access Connector (used by all Cloud Run services)" \
-  "vpcaccess.connectors.create,vpcaccess.connectors.get,vpcaccess.connectors.use"
-
-test_permissions "IAM / Service Accounts (deploy-as ingex-runner-\$ENV)" \
-  "iam.serviceAccounts.actAs,iam.serviceAccounts.get,iam.serviceAccounts.create,iam.serviceAccounts.setIamPolicy"
-
-test_permissions "Monitoring (OTel custom metrics export)" \
-  "monitoring.timeSeries.create,monitoring.metricDescriptors.create"
-
-test_permissions "Service Usage (enabling APIs - only relevant for fresh setup)" \
-  "serviceusage.services.enable,serviceusage.services.get"
+curl -s -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"permissions\": [\"$json_permissions\"]}" \
+    "https://cloudresourcemanager.googleapis.com/v1/projects/${PROJECT}:testIamPermissions" \
+    | jq -r '.permissions[]?' | sort

--- a/tools/check_gcp_permissions.sh
+++ b/tools/check_gcp_permissions.sh
@@ -2,6 +2,11 @@
 
 # Check whether the current gcloud identity has the IAM permissions needed to
 # run index/deploy.sh and ingest/scripts/deploy.sh.
+#
+# There is no `gcloud projects test-iam-permissions` command, so this calls
+# the Cloud Resource Manager `testIamPermissions` API directly via curl using
+# a gcloud-issued access token.
+#
 # Usage: ./check_gcp_permissions.sh
 
 set -e
@@ -10,53 +15,53 @@ echo "=== Identity & Project ==="
 gcloud auth list
 gcloud config get-value project
 PROJECT=$(gcloud config get-value project)
+TOKEN=$(gcloud auth print-access-token)
 
-echo ""
-echo "=== GKE (index/deploy.sh: cluster create/access) ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="container.clusters.get,container.clusters.create,container.clusters.getCredentials,container.clusters.list"
+# Prints only the permissions from $1 (comma-separated) that the current
+# identity actually has on the project; anything missing from the response
+# is a permission they lack.
+test_permissions() {
+    local label="$1"
+    local permissions="$2"
+    local json_permissions
+    json_permissions=$(echo "$permissions" | sed 's/,/", "/g')
 
-echo ""
-echo "=== Cloud Run (ingest/scripts/deploy.sh: deploy services & jobs) ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="run.services.create,run.services.update,run.services.get,run.jobs.create,run.jobs.update,run.jobs.run"
+    echo ""
+    echo "=== $label ==="
+    curl -s -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"permissions\": [\"$json_permissions\"]}" \
+        "https://cloudresourcemanager.googleapis.com/v1/projects/${PROJECT}:testIamPermissions"
+    echo ""
+}
 
-echo ""
-echo "=== Cloud Build (triggered by 'gcloud run deploy --source=.') ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="cloudbuild.builds.create,cloudbuild.builds.get,cloudbuild.builds.list"
+test_permissions "GKE (index/deploy.sh: cluster create/access)" \
+  "container.clusters.get,container.clusters.create,container.clusters.getCredentials,container.clusters.list"
 
-echo ""
-echo "=== Artifact Registry (image push during source-based deploy) ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="artifactregistry.repositories.uploadArtifacts,artifactregistry.repositories.downloadArtifacts,artifactregistry.repositories.get"
+test_permissions "Cloud Run (ingest/scripts/deploy.sh: deploy services & jobs)" \
+  "run.services.create,run.services.update,run.services.get,run.jobs.create,run.jobs.update,run.jobs.run"
 
-echo ""
-echo "=== Secret Manager (env var injection: ES API key, AWS keys) ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="secretmanager.secrets.create,secretmanager.versions.add,secretmanager.versions.access,secretmanager.secrets.get"
+test_permissions "Cloud Build (triggered by 'gcloud run deploy --source=.')" \
+  "cloudbuild.builds.create,cloudbuild.builds.get,cloudbuild.builds.list"
 
-echo ""
-echo "=== Cloud Storage (state files, parquet export, blocklist, ES snapshots) ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="storage.buckets.get,storage.buckets.create,storage.objects.create,storage.objects.get,storage.objects.list"
+test_permissions "Artifact Registry (image push during source-based deploy)" \
+  "artifactregistry.repositories.uploadArtifacts,artifactregistry.repositories.downloadArtifacts,artifactregistry.repositories.get"
 
-echo ""
-echo "=== VPC Access Connector (used by all Cloud Run services) ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="vpcaccess.connectors.create,vpcaccess.connectors.get,vpcaccess.connectors.use"
+test_permissions "Secret Manager (env var injection: ES API key, AWS keys)" \
+  "secretmanager.secrets.create,secretmanager.versions.add,secretmanager.versions.access,secretmanager.secrets.get"
 
-echo ""
-echo "=== IAM / Service Accounts (deploy-as ingex-runner-\$ENV) ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="iam.serviceAccounts.actAs,iam.serviceAccounts.get,iam.serviceAccounts.create,iam.serviceAccounts.setIamPolicy"
+test_permissions "Cloud Storage (state files, parquet export, blocklist, ES snapshots)" \
+  "storage.buckets.get,storage.buckets.create,storage.objects.create,storage.objects.get,storage.objects.list"
 
-echo ""
-echo "=== Monitoring (OTel custom metrics export) ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="monitoring.timeSeries.create,monitoring.metricDescriptors.create"
+test_permissions "VPC Access Connector (used by all Cloud Run services)" \
+  "vpcaccess.connectors.create,vpcaccess.connectors.get,vpcaccess.connectors.use"
 
-echo ""
-echo "=== Service Usage (enabling APIs - only relevant for fresh setup) ==="
-gcloud projects test-iam-permissions $PROJECT \
-  --permissions="serviceusage.services.enable,serviceusage.services.get"
+test_permissions "IAM / Service Accounts (deploy-as ingex-runner-\$ENV)" \
+  "iam.serviceAccounts.actAs,iam.serviceAccounts.get,iam.serviceAccounts.create,iam.serviceAccounts.setIamPolicy"
+
+test_permissions "Monitoring (OTel custom metrics export)" \
+  "monitoring.timeSeries.create,monitoring.metricDescriptors.create"
+
+test_permissions "Service Usage (enabling APIs - only relevant for fresh setup)" \
+  "serviceusage.services.enable,serviceusage.services.get"

--- a/tools/check_gcp_permissions.sh
+++ b/tools/check_gcp_permissions.sh
@@ -10,10 +10,6 @@
 #   ./check_gcp_permissions.sh > teammate.txt   # run by the teammate
 #   diff me.txt teammate.txt
 #
-# There is no `gcloud projects test-iam-permissions` command, so this calls
-# the Cloud Resource Manager `testIamPermissions` API directly via curl using
-# a gcloud-issued access token.
-#
 # Usage: ./check_gcp_permissions.sh
 
 set -e

--- a/tools/check_gcp_permissions.sh
+++ b/tools/check_gcp_permissions.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Check whether the current gcloud identity has the IAM permissions needed to
+# run index/deploy.sh and ingest/scripts/deploy.sh.
+# Usage: ./check_gcp_permissions.sh
+
+set -e
+
+echo "=== Identity & Project ==="
+gcloud auth list
+gcloud config get-value project
+PROJECT=$(gcloud config get-value project)
+
+echo ""
+echo "=== GKE (index/deploy.sh: cluster create/access) ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="container.clusters.get,container.clusters.create,container.clusters.getCredentials,container.clusters.list"
+
+echo ""
+echo "=== Cloud Run (ingest/scripts/deploy.sh: deploy services & jobs) ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="run.services.create,run.services.update,run.services.get,run.jobs.create,run.jobs.update,run.jobs.run"
+
+echo ""
+echo "=== Cloud Build (triggered by 'gcloud run deploy --source=.') ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="cloudbuild.builds.create,cloudbuild.builds.get,cloudbuild.builds.list"
+
+echo ""
+echo "=== Artifact Registry (image push during source-based deploy) ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="artifactregistry.repositories.uploadArtifacts,artifactregistry.repositories.downloadArtifacts,artifactregistry.repositories.get"
+
+echo ""
+echo "=== Secret Manager (env var injection: ES API key, AWS keys) ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="secretmanager.secrets.create,secretmanager.versions.add,secretmanager.versions.access,secretmanager.secrets.get"
+
+echo ""
+echo "=== Cloud Storage (state files, parquet export, blocklist, ES snapshots) ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="storage.buckets.get,storage.buckets.create,storage.objects.create,storage.objects.get,storage.objects.list"
+
+echo ""
+echo "=== VPC Access Connector (used by all Cloud Run services) ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="vpcaccess.connectors.create,vpcaccess.connectors.get,vpcaccess.connectors.use"
+
+echo ""
+echo "=== IAM / Service Accounts (deploy-as ingex-runner-\$ENV) ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="iam.serviceAccounts.actAs,iam.serviceAccounts.get,iam.serviceAccounts.create,iam.serviceAccounts.setIamPolicy"
+
+echo ""
+echo "=== Monitoring (OTel custom metrics export) ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="monitoring.timeSeries.create,monitoring.metricDescriptors.create"
+
+echo ""
+echo "=== Service Usage (enabling APIs - only relevant for fresh setup) ==="
+gcloud projects test-iam-permissions $PROJECT \
+  --permissions="serviceusage.services.enable,serviceusage.services.get"


### PR DESCRIPTION
Adds a tool to help diagnose missing GCP IAM permissions when a teammate runs into issues with `index/deploy.sh` or `ingest/scripts/deploy.sh`.

# This PR

- Add `tools/check_gcp_permissions.sh` — runs `gcloud projects test-iam-permissions` grouped by service area (GKE, Cloud Run, Cloud Build, Artifact Registry, Secret Manager, Cloud Storage, VPC Access, IAM, Monitoring, Service Usage) so a missing permission can be traced to a specific deploy step

# Testing

- Ran the script locally to confirm output is grouped and readable per service area