### PR TITLE
Run post tower and store post embeddings during megastream ingest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,14 @@ export GE_AWS_S3_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 export GE_AWS_S3_BUCKET=my-s3-bucket
 export GE_AWS_S3_PREFIX="data/prefix/"
 
+# Inference Service Configuration (post-tower embeddings; leave GE_INFERENCE_BASE_URL unset to disable)
+# export GE_INFERENCE_BASE_URL="https://inference-stage.greenearth.social"
+# export GE_INFERENCE_API_KEY="your-inference-api-key-here"
+# export GE_INFERENCE_TIMEOUT=10s
+# export GE_INFERENCE_CHUNK_SIZE=1024
+# export GE_INFERENCE_MAX_CONCURRENCY=8
+# export GE_INFERENCE_RETRY_MAX=3
+
 # Jetstream Configuration
 export GE_JETSTREAM_STATE_FILE=".jetstream_state.json"
 export GE_BLOCKLIST_DESTINATION="gs://${GE_GCP_PROJECT_ID}-ingex-blocklist-${GE_ENVIRONMENT}"

--- a/index/deploy/k8s/base/templates/posts-ilm-index-template.yaml
+++ b/index/deploy/k8s/base/templates/posts-ilm-index-template.yaml
@@ -86,6 +86,12 @@ data:
                   "dims": 768,
                   "index": true,
                   "similarity": "cosine"
+                },
+                "ge_post_embedding": {
+                  "type": "dense_vector",
+                  "dims": 128,
+                  "index": true,
+                  "similarity": "cosine"
                 }
               }
             },

--- a/index/deploy/k8s/base/templates/posts-ilm-index-template.yaml
+++ b/index/deploy/k8s/base/templates/posts-ilm-index-template.yaml
@@ -95,6 +95,9 @@ data:
                 }
               }
             },
+            "ge_post_embedding_model_uuid": {
+              "type": "keyword"
+            },
             "indexed_at": {
               "type": "date",
               "format": "iso8601"

--- a/ingest/cmd/megastream_ingest/README.md
+++ b/ingest/cmd/megastream_ingest/README.md
@@ -60,6 +60,29 @@ Configuration is done through environment variables and command line flags.
 - `GE_SPOOL_INTERVAL_SEC` - Polling interval in seconds for spool mode (default: `60`)
 - `GE_MEGASTREAM_STATE_FILE` - Path to state file for cursor tracking (default: `.megastream_state.json`)
 
+**Post-Tower Embeddings (optional):**
+
+When `GE_INFERENCE_BASE_URL` is set, the service calls the inference service's
+post tower for each new non-reply post (inputs: the post's
+`all_MiniLM_L12_v2` content embedding and author DID) and stores the resulting
+128-dim post embedding on the posts index as `embeddings.ge_post_embedding`.
+Failures are fail-open: posts are still indexed without the field. Disabled in
+`--dry-run` mode.
+
+- `GE_INFERENCE_BASE_URL` - Inference service base URL (e.g. `https://inference-stage.greenearth.social`); unset disables post embeddings
+- `GE_INFERENCE_API_KEY` - Inference service API key (GSM secret `inference-api-key-{env}`)
+- `GE_INFERENCE_TIMEOUT` - Per-request HTTP timeout (default: `10s`)
+- `GE_INFERENCE_CHUNK_SIZE` - Posts per inference request; must not exceed the server's `GE_INFERENCE_MAX_BATCH` (default: `1024`)
+- `GE_INFERENCE_MAX_CONCURRENCY` - Concurrent inference requests (default: `8`)
+- `GE_INFERENCE_RETRY_MAX` - Retries beyond the first attempt for transient failures (default: `3`)
+
+> **Rollout ordering:** the `ge_post_embedding` dense_vector mapping must be
+> deployed to the posts index template (`index/deploy.sh <env> --ctypes schema`,
+> then wait for the next index rollover or PUT the mapping onto the current
+> write index) *before* deploying this service with `GE_INFERENCE_BASE_URL`
+> set. Otherwise Elasticsearch dynamically maps the field as `float`, which
+> cannot serve kNN queries and requires a reindex to fix.
+
 ## Usage
 
 ### Basic Usage

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -216,6 +216,9 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 	if config.InferenceBaseURL == "" && !dryRun {
 		return fmt.Errorf("GE_INFERENCE_BASE_URL is required (use --dry-run to skip inference)")
 	}
+	if config.InferenceAPIKey == "" && !dryRun {
+		return fmt.Errorf("GE_INFERENCE_API_KEY is required (use --dry-run to skip inference)")
+	}
 	var embedder *inference.BatchEmbedder
 	if !dryRun {
 		inferenceClient := inference.NewClient(inference.ClientConfig{

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -294,7 +294,8 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 	var tombstoneBatch []common.PostTombstoneDoc
 	var deleteBatch []common.DeleteDoc
 	var hashtagUpdates []common.HashtagUpdate
-	const batchSize = 100
+	const batchSize = 512
+	var pendingFlush *pendingPostFlush
 	processedCount := 0
 	deletedCount := 0
 	skippedCount := 0
@@ -332,6 +333,17 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				// Flush all pending batches before account deletion
 				// This prevents post creation/deletion events from being processed
 				// after the account deletion (which would be out of order)
+
+				// Drain any in-flight async post flush before proceeding
+				if pendingFlush != nil {
+					flushCount, _, flushErr := drainPendingFlush(pendingFlush)
+					pendingFlush = nil
+					if flushErr != nil {
+						logger.Error("Failed to bulk index batch before account deletion: %v", flushErr)
+					} else {
+						processedCount += flushCount
+					}
+				}
 
 				// Flush post creation batch
 				if len(msgs) > 0 {
@@ -456,36 +468,47 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				hashtagUpdates = append(hashtagUpdates, hashtags...)
 
 				if len(msgs) >= batchSize {
-					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					count, err := indexPosts(batchCtx, msgs, esClient, embedder, dryRun, logger)
-					if err != nil {
-						logger.Error("Failed to bulk index batch: %v", err)
-					} else {
-						processedCount += count
-						if lastMsg := msgs[len(msgs)-1]; lastMsg.GetTimeUs() > 0 {
-							logger.Metric("freshness_sec", float64(common.CalculateFreshness(lastMsg.GetTimeUs())))
-						}
-						// Check if a newer instance has started (every 1000 docs to avoid excessive GCS reads)
-						if processedCount%1000 == 0 {
-							if stateManager.CheckForNewerInstance(myStartTime) {
-								logger.Info("Newer instance detected, exiting")
-								cancelBatchCtx()
-								goto cleanup
+					// Drain the previous async post flush and process its result before
+					// dispatching the next batch. By the time a new batch has filled
+					// (batchSize rows), the previous inference + ES write has had the
+					// entire fill window to complete concurrently.
+					if pendingFlush != nil {
+						flushCount, flushLastMsg, flushErr := drainPendingFlush(pendingFlush)
+						pendingFlush = nil
+						if flushErr != nil {
+							logger.Error("Failed to bulk index batch: %v", flushErr)
+						} else {
+							processedCount += flushCount
+							if flushLastMsg != nil && flushLastMsg.GetTimeUs() > 0 {
+								logger.Metric("freshness_sec", float64(common.CalculateFreshness(flushLastMsg.GetTimeUs())))
+							}
+							if processedCount%1000 == 0 {
+								if stateManager.CheckForNewerInstance(myStartTime) {
+									logger.Info("Newer instance detected, exiting")
+									goto cleanup
+								}
+							}
+							if dryRun {
+								logger.Debug("Dry-run: Would index batch: %d documents (total: %d, deleted: %d, skipped: %d)", flushCount, processedCount, deletedCount, skippedCount)
+							} else {
+								logger.Debug("Indexed batch: %d documents (total: %d, deleted: %d, skipped: %d)", flushCount, processedCount, deletedCount, skippedCount)
+							}
+							if flushCount > 0 && (processedCount/flushCount%100) == 0 {
+								logger.Info("Progress: %d documents processed (deleted: %d, skipped: %d)", processedCount, deletedCount, skippedCount)
 							}
 						}
-						if dryRun {
-							logger.Debug("Dry-run: Would index batch: %d documents (total: %d, deleted: %d, skipped: %d)", count, processedCount, deletedCount, skippedCount)
-						} else {
-							logger.Debug("Indexed batch: %d documents (total: %d, deleted: %d, skipped: %d)", count, processedCount, deletedCount, skippedCount)
-						}
-						// Log info every 100 batches (~10k documents)
-						if (processedCount / count % 100) == 0 {
-							logger.Info("Progress: %d documents processed (deleted: %d, skipped: %d)", processedCount, deletedCount, skippedCount)
-						}
 					}
-					msgs = msgs[:0]
 
-					// Flush inferences batch when posts batch is flushed
+					// Transfer slice ownership to the goroutine; give the main loop a
+					// fresh backing array so appends don't race with the goroutine.
+					batchMsgs := msgs
+					msgs = make([]common.MegaStreamMessage, 0, batchSize)
+					pendingFlush = dispatchIndexPosts(batchMsgs, esClient, embedder, dryRun, logger)
+
+					// Flush inferences and hashtags synchronously — they are fast
+					// (no inference service call) and should stay ordered with posts.
+					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
+
 					if len(inferencesBatch) > 0 {
 						if err := common.BulkIndexInferences(batchCtx, esClient, "inferences", inferencesBatch, dryRun, logger); err != nil {
 							logger.Error("Failed to bulk index inferences: %v", err)
@@ -497,7 +520,6 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 						inferencesBatch = inferencesBatch[:0]
 					}
 
-					// Flush hashtag updates when posts batch is flushed
 					if len(hashtagUpdates) > 0 {
 						if err := common.BulkUpdateHashtagCounts(batchCtx, esClient, "hashtags", hashtagUpdates, dryRun, logger); err != nil {
 							logger.Error("Failed to bulk update hashtag counts: %v", err)
@@ -522,6 +544,16 @@ cleanup:
 	// Create a separate context for cleanup operations with a 30-second timeout
 	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cleanupCancel()
+
+	// Drain any in-flight async post flush before writing the final batch
+	if pendingFlush != nil {
+		flushCount, _, flushErr := drainPendingFlush(pendingFlush)
+		if flushErr != nil {
+			logger.Error("Failed to bulk index in-flight batch during cleanup: %v", flushErr)
+		} else {
+			processedCount += flushCount
+		}
+	}
 
 	// Index remaining documents in batch
 	if len(msgs) > 0 {
@@ -589,6 +621,37 @@ cleanup:
 
 	logger.Info("Spooler ingestion complete. Processed: %d, Deleted: %d, Skipped: %d, Hashtag updates: %d", processedCount, deletedCount, skippedCount, hashtagCount)
 	return nil
+}
+
+type postFlushResult struct {
+	count   int
+	err     error
+	lastMsg common.MegaStreamMessage
+}
+
+type pendingPostFlush struct {
+	ch        <-chan postFlushResult
+	cancelCtx context.CancelFunc
+}
+
+func drainPendingFlush(pending *pendingPostFlush) (int, common.MegaStreamMessage, error) {
+	r := <-pending.ch
+	pending.cancelCtx()
+	return r.count, r.lastMsg, r.err
+}
+
+func dispatchIndexPosts(msgs []common.MegaStreamMessage, esClient *elasticsearch.Client, embedder *inference.BatchEmbedder, dryRun bool, logger *common.IngestLogger) *pendingPostFlush {
+	batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
+	ch := make(chan postFlushResult, 1)
+	var lastMsg common.MegaStreamMessage
+	if len(msgs) > 0 {
+		lastMsg = msgs[len(msgs)-1]
+	}
+	go func() {
+		count, err := indexPosts(batchCtx, msgs, esClient, embedder, dryRun, logger)
+		ch <- postFlushResult{count: count, err: err, lastMsg: lastMsg}
+	}()
+	return &pendingPostFlush{ch: ch, cancelCtx: cancelBatchCtx}
 }
 
 // indexPosts creates Elasticsearch documents from messages and indexes them

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/elastic/go-elasticsearch/v9"
 	"github.com/greenearth/ingest/internal/common"
+	"github.com/greenearth/ingest/internal/inference"
 	"github.com/greenearth/ingest/internal/megastream_ingest"
 )
 
@@ -213,6 +214,22 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 		return err
 	}
 
+	// Initialize post-tower embedder when the inference service is configured.
+	// A nil embedder disables post embedding generation (AttachPostTowerEmbeddings is a no-op).
+	var embedder *inference.BatchEmbedder
+	if config.InferenceBaseURL != "" && !dryRun {
+		inferenceClient := inference.NewClient(inference.ClientConfig{
+			BaseURL:    config.InferenceBaseURL,
+			APIKey:     config.InferenceAPIKey,
+			Timeout:    config.InferenceTimeout,
+			MaxRetries: config.InferenceRetryMax,
+		}, logger)
+		embedder = inference.NewBatchEmbedder(inferenceClient, config.InferenceChunkSize, config.InferenceMaxConcurrency, logger)
+		logger.Info("Post-tower embeddings enabled (inference service: %s)", config.InferenceBaseURL)
+	} else {
+		logger.Info("Post-tower embeddings disabled (GE_INFERENCE_BASE_URL not set or dry-run)")
+	}
+
 	// Ensure period-based indices exist and are the write target for posts and
 	// post_tombstones. Runs at startup and every minute so that period rollovers
 	// are detected promptly without waiting for the next batch flush.
@@ -319,7 +336,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 				// Flush post creation batch
 				if len(msgs) > 0 {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					count, err := indexPosts(batchCtx, msgs, esClient, dryRun, logger)
+					count, err := indexPosts(batchCtx, msgs, esClient, embedder, dryRun, logger)
 					if err != nil {
 						logger.Error("Failed to index batch before account deletion: %v", err)
 					} else {
@@ -440,7 +457,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 
 				if len(msgs) >= batchSize {
 					batchCtx, cancelBatchCtx := context.WithTimeout(context.Background(), 30*time.Second)
-					count, err := indexPosts(batchCtx, msgs, esClient, dryRun, logger)
+					count, err := indexPosts(batchCtx, msgs, esClient, embedder, dryRun, logger)
 					if err != nil {
 						logger.Error("Failed to bulk index batch: %v", err)
 					} else {
@@ -508,7 +525,7 @@ cleanup:
 
 	// Index remaining documents in batch
 	if len(msgs) > 0 {
-		count, err := indexPosts(cleanupCtx, msgs, esClient, dryRun, logger)
+		count, err := indexPosts(cleanupCtx, msgs, esClient, embedder, dryRun, logger)
 		if err != nil {
 			logger.Error("Failed to bulk index final batch: %v", err)
 		} else {
@@ -577,7 +594,7 @@ cleanup:
 // indexPosts creates Elasticsearch documents from messages and indexes them
 // Like counts start at 0 and are incremented by jetstream when likes arrive
 // Returns the number of documents indexed
-func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *elasticsearch.Client, dryRun bool, logger *common.IngestLogger) (int, error) {
+func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *elasticsearch.Client, embedder *inference.BatchEmbedder, dryRun bool, logger *common.IngestLogger) (int, error) {
 	if len(msgs) == 0 {
 		return 0, nil
 	}
@@ -587,6 +604,8 @@ func indexPosts(ctx context.Context, msgs []common.MegaStreamMessage, esClient *
 		doc := common.CreateElasticsearchDoc(m, 0)
 		batch = append(batch, doc)
 	}
+
+	inference.AttachPostTowerEmbeddings(ctx, embedder, batch)
 
 	if err := common.BulkIndex(ctx, esClient, "posts", batch, dryRun, logger); err != nil {
 		return 0, fmt.Errorf("failed to bulk index batch: %w", err)

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -214,10 +214,11 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 		return err
 	}
 
-	// Initialize post-tower embedder when the inference service is configured.
-	// A nil embedder disables post embedding generation (AttachPostTowerEmbeddings is a no-op).
+	if config.InferenceBaseURL == "" && !dryRun {
+		return fmt.Errorf("GE_INFERENCE_BASE_URL is required (use --dry-run to skip inference)")
+	}
 	var embedder *inference.BatchEmbedder
-	if config.InferenceBaseURL != "" && !dryRun {
+	if !dryRun {
 		inferenceClient := inference.NewClient(inference.ClientConfig{
 			BaseURL:    config.InferenceBaseURL,
 			APIKey:     config.InferenceAPIKey,
@@ -227,7 +228,7 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 		embedder = inference.NewBatchEmbedder(inferenceClient, config.InferenceChunkSize, config.InferenceMaxConcurrency, logger)
 		logger.Info("Post-tower embeddings enabled (inference service: %s)", config.InferenceBaseURL)
 	} else {
-		logger.Info("Post-tower embeddings disabled (GE_INFERENCE_BASE_URL not set or dry-run)")
+		logger.Info("Post-tower embeddings disabled (dry-run)")
 	}
 
 	// Ensure period-based indices exist and are the write target for posts and

--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -336,13 +336,9 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 
 				// Drain any in-flight async post flush before proceeding
 				if pendingFlush != nil {
-					flushCount, _, flushErr := drainPendingFlush(pendingFlush)
+					flushCount, _ := drainPendingFlush(pendingFlush)
 					pendingFlush = nil
-					if flushErr != nil {
-						logger.Error("Failed to bulk index batch before account deletion: %v", flushErr)
-					} else {
-						processedCount += flushCount
-					}
+					processedCount += flushCount
 				}
 
 				// Flush post creation batch
@@ -450,29 +446,25 @@ func runIngestion(ctx context.Context, config *common.Config, logger *common.Ing
 					// (batchSize rows), the previous inference + ES write has had the
 					// entire fill window to complete concurrently.
 					if pendingFlush != nil {
-						flushCount, flushLastMsg, flushErr := drainPendingFlush(pendingFlush)
+						flushCount, flushLastMsg := drainPendingFlush(pendingFlush)
 						pendingFlush = nil
-						if flushErr != nil {
-							logger.Error("Failed to bulk index batch: %v", flushErr)
+						processedCount += flushCount
+						if flushLastMsg != nil && flushLastMsg.GetTimeUs() > 0 {
+							logger.Metric("freshness_sec", float64(common.CalculateFreshness(flushLastMsg.GetTimeUs())))
+						}
+						if processedCount%1000 == 0 {
+							if stateManager.CheckForNewerInstance(myStartTime) {
+								logger.Info("Newer instance detected, exiting")
+								goto cleanup
+							}
+						}
+						if dryRun {
+							logger.Debug("Dry-run: Would index batch: %d documents (total: %d, deleted: %d, skipped: %d)", flushCount, processedCount, deletedCount, skippedCount)
 						} else {
-							processedCount += flushCount
-							if flushLastMsg != nil && flushLastMsg.GetTimeUs() > 0 {
-								logger.Metric("freshness_sec", float64(common.CalculateFreshness(flushLastMsg.GetTimeUs())))
-							}
-							if processedCount%1000 == 0 {
-								if stateManager.CheckForNewerInstance(myStartTime) {
-									logger.Info("Newer instance detected, exiting")
-									goto cleanup
-								}
-							}
-							if dryRun {
-								logger.Debug("Dry-run: Would index batch: %d documents (total: %d, deleted: %d, skipped: %d)", flushCount, processedCount, deletedCount, skippedCount)
-							} else {
-								logger.Debug("Indexed batch: %d documents (total: %d, deleted: %d, skipped: %d)", flushCount, processedCount, deletedCount, skippedCount)
-							}
-							if flushCount > 0 && (processedCount/flushCount%100) == 0 {
-								logger.Info("Progress: %d documents processed (deleted: %d, skipped: %d)", processedCount, deletedCount, skippedCount)
-							}
+							logger.Debug("Indexed batch: %d documents (total: %d, deleted: %d, skipped: %d)", flushCount, processedCount, deletedCount, skippedCount)
+						}
+						if flushCount > 0 && (processedCount/flushCount%100) == 0 {
+							logger.Info("Progress: %d documents processed (deleted: %d, skipped: %d)", processedCount, deletedCount, skippedCount)
 						}
 					}
 
@@ -524,12 +516,8 @@ cleanup:
 
 	// Drain any in-flight async post flush before writing the final batch
 	if pendingFlush != nil {
-		flushCount, _, flushErr := drainPendingFlush(pendingFlush)
-		if flushErr != nil {
-			logger.Error("Failed to bulk index in-flight batch during cleanup: %v", flushErr)
-		} else {
-			processedCount += flushCount
-		}
+		flushCount, _ := drainPendingFlush(pendingFlush)
+		processedCount += flushCount
 	}
 
 	// Index remaining documents in batch
@@ -588,7 +576,6 @@ cleanup:
 
 type postFlushResult struct {
 	count   int
-	err     error
 	lastMsg common.MegaStreamMessage
 }
 
@@ -597,10 +584,10 @@ type pendingPostFlush struct {
 	cancelCtx context.CancelFunc
 }
 
-func drainPendingFlush(pending *pendingPostFlush) (int, common.MegaStreamMessage, error) {
+func drainPendingFlush(pending *pendingPostFlush) (int, common.MegaStreamMessage) {
 	r := <-pending.ch
 	pending.cancelCtx()
-	return r.count, r.lastMsg, r.err
+	return r.count, r.lastMsg
 }
 
 func dispatchIndexPosts(msgs []common.MegaStreamMessage, esClient *elasticsearch.Client, embedder *inference.BatchEmbedder, dryRun bool, logger *common.IngestLogger) *pendingPostFlush {

--- a/ingest/go.mod
+++ b/ingest/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	golang.org/x/sync v0.20.0
 	modernc.org/sqlite v1.49.1
 )
 
@@ -78,7 +79,6 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/ingest/internal/common/config.go
+++ b/ingest/internal/common/config.go
@@ -111,7 +111,7 @@ func LoadConfig() *Config {
 		InferenceBaseURL:           getEnv("GE_INFERENCE_BASE_URL", ""),
 		InferenceAPIKey:            getEnv("GE_INFERENCE_API_KEY", ""),
 		InferenceTimeout:           getEnvDuration("GE_INFERENCE_TIMEOUT", 10*time.Second),
-		InferenceChunkSize:         getEnvInt("GE_INFERENCE_CHUNK_SIZE", 1024),
+		InferenceChunkSize:         getEnvInt("GE_INFERENCE_CHUNK_SIZE", 64),
 		InferenceMaxConcurrency:    getEnvInt("GE_INFERENCE_MAX_CONCURRENCY", 8),
 		InferenceRetryMax:          getEnvInt("GE_INFERENCE_RETRY_MAX", 3),
 	}

--- a/ingest/internal/common/config.go
+++ b/ingest/internal/common/config.go
@@ -65,6 +65,14 @@ type Config struct {
 
 	// Index period configuration
 	IndexPeriod string // GE_INDEX_PERIOD: "week", "hour", or "10min"
+
+	// Inference service configuration
+	InferenceBaseURL        string        // GE_INFERENCE_BASE_URL; empty disables post-tower embeddings
+	InferenceAPIKey         string        // GE_INFERENCE_API_KEY
+	InferenceTimeout        time.Duration // GE_INFERENCE_TIMEOUT, per-request HTTP timeout
+	InferenceChunkSize      int           // GE_INFERENCE_CHUNK_SIZE, must be <= server GE_INFERENCE_MAX_BATCH
+	InferenceMaxConcurrency int           // GE_INFERENCE_MAX_CONCURRENCY, concurrent inference requests
+	InferenceRetryMax       int           // GE_INFERENCE_RETRY_MAX, retries beyond the first attempt
 }
 
 // LoadConfig loads configuration from environment variables with defaults
@@ -100,6 +108,12 @@ func LoadConfig() *Config {
 		LikeRateLimitWindowMinutes: getEnvInt("GE_LIKE_RATE_LIMIT_WINDOW_MIN", 5),
 		LikeBlockDurationMinutes:   getEnvInt("GE_LIKE_BLOCK_DURATION_MIN", 60),
 		IndexPeriod:                getEnv("GE_INDEX_PERIOD", IndexPeriod10Min),
+		InferenceBaseURL:           getEnv("GE_INFERENCE_BASE_URL", ""),
+		InferenceAPIKey:            getEnv("GE_INFERENCE_API_KEY", ""),
+		InferenceTimeout:           getEnvDuration("GE_INFERENCE_TIMEOUT", 10*time.Second),
+		InferenceChunkSize:         getEnvInt("GE_INFERENCE_CHUNK_SIZE", 1024),
+		InferenceMaxConcurrency:    getEnvInt("GE_INFERENCE_MAX_CONCURRENCY", 8),
+		InferenceRetryMax:          getEnvInt("GE_INFERENCE_RETRY_MAX", 3),
 	}
 }
 

--- a/ingest/internal/common/config_test.go
+++ b/ingest/internal/common/config_test.go
@@ -155,6 +155,12 @@ func clearEnvVars() {
 		"GE_GCP_PROJECT_ID",
 		"GE_GCP_REGION",
 		"GE_ENVIRONMENT",
+		"GE_INFERENCE_BASE_URL",
+		"GE_INFERENCE_API_KEY",
+		"GE_INFERENCE_TIMEOUT",
+		"GE_INFERENCE_CHUNK_SIZE",
+		"GE_INFERENCE_MAX_CONCURRENCY",
+		"GE_INFERENCE_RETRY_MAX",
 		"PORT",
 	}
 
@@ -167,5 +173,62 @@ func setEnvForTest(t *testing.T, key, value string) {
 	t.Helper()
 	if err := os.Setenv(key, value); err != nil {
 		t.Fatalf("Failed to set environment variable %s: %v", key, err)
+	}
+}
+
+func TestLoadConfig_InferenceDefaults(t *testing.T) {
+	clearEnvVars()
+
+	config := LoadConfig()
+
+	if config.InferenceBaseURL != "" {
+		t.Errorf("Expected default InferenceBaseURL to be empty (disabled), got %s", config.InferenceBaseURL)
+	}
+	if config.InferenceAPIKey != "" {
+		t.Errorf("Expected default InferenceAPIKey to be empty, got %s", config.InferenceAPIKey)
+	}
+	if config.InferenceTimeout != 10*time.Second {
+		t.Errorf("Expected default InferenceTimeout to be 10s, got %v", config.InferenceTimeout)
+	}
+	if config.InferenceChunkSize != 1024 {
+		t.Errorf("Expected default InferenceChunkSize to be 1024, got %d", config.InferenceChunkSize)
+	}
+	if config.InferenceMaxConcurrency != 8 {
+		t.Errorf("Expected default InferenceMaxConcurrency to be 8, got %d", config.InferenceMaxConcurrency)
+	}
+	if config.InferenceRetryMax != 3 {
+		t.Errorf("Expected default InferenceRetryMax to be 3, got %d", config.InferenceRetryMax)
+	}
+}
+
+func TestLoadConfig_InferenceFromEnvironment(t *testing.T) {
+	setEnvForTest(t, "GE_INFERENCE_BASE_URL", "https://inference-stage.greenearth.social")
+	setEnvForTest(t, "GE_INFERENCE_API_KEY", "test-key")
+	setEnvForTest(t, "GE_INFERENCE_TIMEOUT", "30s")
+	setEnvForTest(t, "GE_INFERENCE_CHUNK_SIZE", "256")
+	setEnvForTest(t, "GE_INFERENCE_MAX_CONCURRENCY", "16")
+	setEnvForTest(t, "GE_INFERENCE_RETRY_MAX", "5")
+
+	defer clearEnvVars()
+
+	config := LoadConfig()
+
+	if config.InferenceBaseURL != "https://inference-stage.greenearth.social" {
+		t.Errorf("Expected InferenceBaseURL from env, got %s", config.InferenceBaseURL)
+	}
+	if config.InferenceAPIKey != "test-key" {
+		t.Errorf("Expected InferenceAPIKey from env, got %s", config.InferenceAPIKey)
+	}
+	if config.InferenceTimeout != 30*time.Second {
+		t.Errorf("Expected InferenceTimeout from env to be 30s, got %v", config.InferenceTimeout)
+	}
+	if config.InferenceChunkSize != 256 {
+		t.Errorf("Expected InferenceChunkSize from env to be 256, got %d", config.InferenceChunkSize)
+	}
+	if config.InferenceMaxConcurrency != 16 {
+		t.Errorf("Expected InferenceMaxConcurrency from env to be 16, got %d", config.InferenceMaxConcurrency)
+	}
+	if config.InferenceRetryMax != 5 {
+		t.Errorf("Expected InferenceRetryMax from env to be 5, got %d", config.InferenceRetryMax)
 	}
 }

--- a/ingest/internal/common/config_test.go
+++ b/ingest/internal/common/config_test.go
@@ -190,8 +190,8 @@ func TestLoadConfig_InferenceDefaults(t *testing.T) {
 	if config.InferenceTimeout != 10*time.Second {
 		t.Errorf("Expected default InferenceTimeout to be 10s, got %v", config.InferenceTimeout)
 	}
-	if config.InferenceChunkSize != 1024 {
-		t.Errorf("Expected default InferenceChunkSize to be 1024, got %d", config.InferenceChunkSize)
+	if config.InferenceChunkSize != 64 {
+		t.Errorf("Expected default InferenceChunkSize to be 64, got %d", config.InferenceChunkSize)
 	}
 	if config.InferenceMaxConcurrency != 8 {
 		t.Errorf("Expected default InferenceMaxConcurrency to be 8, got %d", config.InferenceMaxConcurrency)

--- a/ingest/internal/common/elasticsearch.go
+++ b/ingest/internal/common/elasticsearch.go
@@ -63,7 +63,8 @@ type ElasticsearchDoc struct {
 	ThreadRootPost   string                  `json:"thread_root_post,omitempty"`
 	ThreadParentPost string                  `json:"thread_parent_post,omitempty"`
 	QuotePost        string                  `json:"quote_post,omitempty"`
-	Embeddings       map[string]Float32Array `json:"embeddings,omitempty"`
+	Embeddings              map[string]Float32Array `json:"embeddings,omitempty"`
+	PostEmbeddingModelUUID  string                  `json:"ge_post_embedding_model_uuid,omitempty"`
 	IndexedAt        string                  `json:"indexed_at"`
 	LikeCount        int                     `json:"like_count"`
 	Media                   []MediaItem             `json:"media,omitempty"`

--- a/ingest/internal/common/megastream_message.go
+++ b/ingest/internal/common/megastream_message.go
@@ -3,6 +3,8 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/greenearth/ingest/internal/embeddings"
 )
 
 // MegaStreamMessage defines the interface for processing messages from the MegaStream database
@@ -272,14 +274,14 @@ func (m *megaStreamMessage) parseInferences(inferencesJSON string, logger *Inges
 
 	if textEmbeddings, ok := inferences["text_embeddings"].(map[string]interface{}); ok {
 		if embL12, ok := textEmbeddings["all-MiniLM-L12-v2"].(string); ok {
-			if decoded, err := decodeEmbedding(embL12); err == nil {
+			if decoded, err := embeddings.Decode(embL12); err == nil {
 				m.embeddings["all_MiniLM_L12_v2"] = decoded
 			} else {
 				logger.Debug("Failed to decode L12 embedding for %s: %v", m.atURI, err)
 			}
 		}
 		if embL6, ok := textEmbeddings["all-MiniLM-L6-v2"].(string); ok {
-			if decoded, err := decodeEmbedding(embL6); err == nil {
+			if decoded, err := embeddings.Decode(embL6); err == nil {
 				m.embeddings["all_MiniLM_L6_v2"] = decoded
 			} else {
 				logger.Debug("Failed to decode L6 embedding for %s: %v", m.atURI, err)
@@ -302,7 +304,7 @@ func (m *megaStreamMessage) parseInferences(inferencesJSON string, logger *Inges
 
 	if embeddingsMap, ok := audioTranscription["embeddings"].(map[string]interface{}); ok {
 		if embGemma, ok := embeddingsMap["google/embeddinggemma-300m"].(string); ok {
-			if decoded, err := decodeEmbedding(embGemma); err == nil {
+			if decoded, err := embeddings.Decode(embGemma); err == nil {
 				m.embeddings["google_embeddinggemma_300m"] = decoded
 			} else {
 				logger.Debug("Failed to decode embeddinggemma-300m for %s: %v", m.atURI, err)

--- a/ingest/internal/common/parquet.go
+++ b/ingest/internal/common/parquet.go
@@ -1,5 +1,7 @@
 package common
 
+import "github.com/greenearth/ingest/internal/embeddings"
+
 // ExtractPost represents the Post document structure for Parquet serialization
 // Field names match the expected parquet output format
 type ExtractPost struct {
@@ -31,7 +33,7 @@ func HitToExtractPost(hit Hit) ExtractPost {
 	if len(hit.Source.Embeddings) > 0 {
 		extractPost.Embeddings = make(map[string]string, len(hit.Source.Embeddings))
 		for modelName, floatArray := range hit.Source.Embeddings {
-			if encoded, err := encodeEmbedding(floatArray); err == nil {
+			if encoded, err := embeddings.Encode(floatArray); err == nil {
 				extractPost.Embeddings[modelName] = encoded
 			}
 			// Silently skip embeddings that fail to encode

--- a/ingest/internal/embeddings/codec.go
+++ b/ingest/internal/embeddings/codec.go
@@ -1,18 +1,7 @@
-package common
-
-import (
-	"bytes"
-	"compress/zlib"
-	"encoding/binary"
-	"fmt"
-	"io"
-	"math"
-	"strings"
-)
-
-// Embedding encoding/decoding utilities for converting between float32 arrays
-// and base85-encoded, zlib-compressed strings. This matches the Python
-// implementation using base64.b85encode/decode and zlib compression.
+// Package embeddings provides encoding/decoding utilities for converting
+// between float32 arrays and base85-encoded, zlib-compressed strings. This
+// matches the Python implementation using base64.b85encode/decode and zlib
+// compression.
 //
 // The encoding process:
 // 1. Pack float32 values as little-endian binary data
@@ -23,6 +12,17 @@ import (
 // 1. Decode base85 using RFC 1924 alphabet
 // 2. Decompress with zlib
 // 3. Unpack little-endian binary to float32 values
+package embeddings
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+)
 
 const base85Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+-;<=>?@^_`{|}~"
 
@@ -128,8 +128,8 @@ func encodeBase85RFC1924(data []byte) (string, error) {
 	return output, nil
 }
 
-// decodeEmbedding decodes a base85-encoded, zlib-compressed embedding string to float32 array
-func decodeEmbedding(encoded string) ([]float32, error) {
+// Decode decodes a base85-encoded, zlib-compressed embedding string to a float32 array
+func Decode(encoded string) ([]float32, error) {
 	decoded, err := decodeBase85RFC1924(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("base85 decode failed: %w", err)
@@ -159,10 +159,10 @@ func decodeEmbedding(encoded string) ([]float32, error) {
 	return floats, nil
 }
 
-// encodeEmbedding encodes a float32 array to a base85-encoded, zlib-compressed string
-// This is the reverse of decodeEmbedding
+// Encode encodes a float32 array to a base85-encoded, zlib-compressed string
+// This is the reverse of Decode
 // Process: pack little-endian float32s → zlib compress → base85 encode
-func encodeEmbedding(floats []float32) (string, error) {
+func Encode(floats []float32) (string, error) {
 	if len(floats) == 0 {
 		return "", nil
 	}

--- a/ingest/internal/embeddings/codec_test.go
+++ b/ingest/internal/embeddings/codec_test.go
@@ -1,13 +1,13 @@
-package common
+package embeddings
 
 import (
 	"bytes"
 	"math"
+	"math/rand"
 	"testing"
 )
 
 // TestDecodeBase85RFC1924 tests the base85 decoding function
-// Test data moved from megastream_message_test.go
 func TestDecodeBase85RFC1924(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -127,8 +127,8 @@ func TestBase85RFC1924RoundTrip(t *testing.T) {
 	}
 }
 
-// TestDecodeEmbedding tests the embedding decoding function
-func TestDecodeEmbedding(t *testing.T) {
+// TestDecode tests the embedding decoding function
+func TestDecode(t *testing.T) {
 	tests := []struct {
 		name     string
 		encoded  string
@@ -158,9 +158,9 @@ func TestDecodeEmbedding(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			decoded, err := decodeEmbedding(tt.encoded)
+			decoded, err := Decode(tt.encoded)
 			if err != nil {
-				t.Fatalf("decodeEmbedding() error = %v, expected nil", err)
+				t.Fatalf("Decode() error = %v, expected nil", err)
 			}
 
 			if len(decoded) != len(tt.expected) {
@@ -176,10 +176,10 @@ func TestDecodeEmbedding(t *testing.T) {
 	}
 }
 
-// TestEncodeEmbedding tests the embedding encoding function
+// TestEncode tests the embedding encoding function
 // Note: We don't test for exact match with Python output because different zlib
 // implementations can produce different (but valid) compressed outputs
-func TestEncodeEmbedding(t *testing.T) {
+func TestEncode(t *testing.T) {
 	tests := []struct {
 		name   string
 		floats []float32
@@ -200,15 +200,14 @@ func TestEncodeEmbedding(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			encoded, err := encodeEmbedding(tt.floats)
+			encoded, err := Encode(tt.floats)
 			if err != nil {
-				t.Fatalf("encodeEmbedding() error = %v, expected nil", err)
+				t.Fatalf("Encode() error = %v, expected nil", err)
 			}
 
-			// Verify we can decode it back
-			decoded, err := decodeEmbedding(encoded)
+			decoded, err := Decode(encoded)
 			if err != nil {
-				t.Fatalf("decodeEmbedding() error = %v, expected nil", err)
+				t.Fatalf("Decode() error = %v, expected nil", err)
 			}
 
 			if len(decoded) != len(tt.floats) {
@@ -224,8 +223,8 @@ func TestEncodeEmbedding(t *testing.T) {
 	}
 }
 
-// TestEmbeddingRoundTrip tests that encoding and decoding embeddings are inverse operations
-func TestEmbeddingRoundTrip(t *testing.T) {
+// TestRoundTrip tests that encoding and decoding embeddings are inverse operations
+func TestRoundTrip(t *testing.T) {
 	tests := []struct {
 		name   string
 		floats []float32
@@ -240,14 +239,14 @@ func TestEmbeddingRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			encoded, err := encodeEmbedding(tt.floats)
+			encoded, err := Encode(tt.floats)
 			if err != nil {
-				t.Fatalf("encodeEmbedding() error = %v", err)
+				t.Fatalf("Encode() error = %v", err)
 			}
 
-			decoded, err := decodeEmbedding(encoded)
+			decoded, err := Decode(encoded)
 			if err != nil {
-				t.Fatalf("decodeEmbedding() error = %v", err)
+				t.Fatalf("Decode() error = %v", err)
 			}
 
 			if len(decoded) != len(tt.floats) {
@@ -255,7 +254,6 @@ func TestEmbeddingRoundTrip(t *testing.T) {
 			}
 
 			for i := range decoded {
-				// Handle special values
 				if math.IsInf(float64(tt.floats[i]), 0) {
 					if !math.IsInf(float64(decoded[i]), 0) || math.Signbit(float64(tt.floats[i])) != math.Signbit(float64(decoded[i])) {
 						t.Errorf("infinity mismatch at index %d: got %v, want %v", i, decoded[i], tt.floats[i])
@@ -268,7 +266,6 @@ func TestEmbeddingRoundTrip(t *testing.T) {
 					}
 					continue
 				}
-				// Regular values should match exactly (bit-level)
 				if decoded[i] != tt.floats[i] {
 					t.Errorf("value mismatch at index %d: got %v, want %v", i, decoded[i], tt.floats[i])
 				}
@@ -277,25 +274,54 @@ func TestEmbeddingRoundTrip(t *testing.T) {
 	}
 }
 
-// TestEmbeddingRoundTripNaN tests NaN values separately since NaN != NaN
-func TestEmbeddingRoundTripNaN(t *testing.T) {
-	floats := []float32{float32(math.NaN()), 1.0, float32(math.NaN())}
-
-	encoded, err := encodeEmbedding(floats)
-	if err != nil {
-		t.Fatalf("encodeEmbedding() error = %v", err)
+// TestRoundTrip384Dim tests round-tripping a realistic 384-dimension embedding
+// (the dimension of all-MiniLM-L12-v2 content embeddings)
+func TestRoundTrip384Dim(t *testing.T) {
+	rng := rand.New(rand.NewSource(372))
+	floats := make([]float32, 384)
+	for i := range floats {
+		floats[i] = rng.Float32()*2 - 1
 	}
 
-	decoded, err := decodeEmbedding(encoded)
+	encoded, err := Encode(floats)
 	if err != nil {
-		t.Fatalf("decodeEmbedding() error = %v", err)
+		t.Fatalf("Encode() error = %v", err)
+	}
+
+	decoded, err := Decode(encoded)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+
+	if len(decoded) != 384 {
+		t.Fatalf("length mismatch: got %d, want 384", len(decoded))
+	}
+
+	for i := range decoded {
+		if decoded[i] != floats[i] {
+			t.Errorf("value mismatch at index %d: got %v, want %v", i, decoded[i], floats[i])
+		}
+	}
+}
+
+// TestRoundTripNaN tests NaN values separately since NaN != NaN
+func TestRoundTripNaN(t *testing.T) {
+	floats := []float32{float32(math.NaN()), 1.0, float32(math.NaN())}
+
+	encoded, err := Encode(floats)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+
+	decoded, err := Decode(encoded)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
 	}
 
 	if len(decoded) != len(floats) {
 		t.Fatalf("length mismatch: got %d, want %d", len(decoded), len(floats))
 	}
 
-	// Check NaN values
 	if !math.IsNaN(float64(decoded[0])) {
 		t.Errorf("expected NaN at index 0, got %v", decoded[0])
 	}
@@ -315,8 +341,6 @@ func floatsAlmostEqual(a, b float32) bool {
 	if math.IsInf(float64(a), 0) && math.IsInf(float64(b), 0) {
 		return math.Signbit(float64(a)) == math.Signbit(float64(b))
 	}
-	// For most values, require exact match (bit-level)
-	// For values like 99.9 that can't be represented exactly, allow small tolerance
 	const epsilon = 1e-5
 	diff := a - b
 	if diff < 0 {

--- a/ingest/internal/inference/batch.go
+++ b/ingest/internal/inference/batch.go
@@ -1,0 +1,98 @@
+package inference
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/greenearth/ingest/internal/common"
+)
+
+// PostEmbeddingInput is a single post to compute a post-tower embedding for
+type PostEmbeddingInput struct {
+	AtURI     string    // correlation ID
+	Embedding []float32 // content embedding (all_MiniLM_L12_v2)
+	AuthorDID string
+}
+
+// PostEmbeddingResult is the outcome for a single input. Embedding is nil and
+// Err is set when the input's chunk failed.
+type PostEmbeddingResult struct {
+	AtURI     string
+	Embedding []float32
+	Err       error
+}
+
+// BatchEmbedder fans out post-tower inference over chunks of inputs with
+// bounded concurrency. Failures are isolated per chunk so one failed chunk
+// never affects the others (fail-open).
+type BatchEmbedder struct {
+	client         *Client
+	chunkSize      int
+	maxConcurrency int
+	logger         *common.IngestLogger
+}
+
+// NewBatchEmbedder creates a BatchEmbedder. chunkSize must not exceed the
+// inference service's GE_INFERENCE_MAX_BATCH.
+func NewBatchEmbedder(client *Client, chunkSize, maxConcurrency int, logger *common.IngestLogger) *BatchEmbedder {
+	if chunkSize <= 0 {
+		chunkSize = 1024
+	}
+	if maxConcurrency <= 0 {
+		maxConcurrency = 1
+	}
+	return &BatchEmbedder{
+		client:         client,
+		chunkSize:      chunkSize,
+		maxConcurrency: maxConcurrency,
+		logger:         logger,
+	}
+}
+
+// ComputePostEmbeddings computes post-tower embeddings for all inputs,
+// querying the inference service concurrently in chunks. Results are returned
+// in input order. It never returns an error; per-input failures are recorded
+// in PostEmbeddingResult.Err.
+func (b *BatchEmbedder) ComputePostEmbeddings(ctx context.Context, inputs []PostEmbeddingInput) []PostEmbeddingResult {
+	results := make([]PostEmbeddingResult, len(inputs))
+	if len(inputs) == 0 {
+		return results
+	}
+
+	var group errgroup.Group
+	group.SetLimit(b.maxConcurrency)
+
+	for start := 0; start < len(inputs); start += b.chunkSize {
+		end := min(start+b.chunkSize, len(inputs))
+		chunk := inputs[start:end]
+		chunkResults := results[start:end]
+
+		group.Go(func() error {
+			embeddings := make([][]float32, len(chunk))
+			authorDIDs := make([]string, len(chunk))
+			for i, input := range chunk {
+				embeddings[i] = input.Embedding
+				authorDIDs[i] = input.AuthorDID
+			}
+
+			outputs, err := b.client.PostTowerPredict(ctx, embeddings, authorDIDs)
+			for i, input := range chunk {
+				chunkResults[i].AtURI = input.AtURI
+				if err != nil {
+					chunkResults[i].Err = err
+				} else {
+					chunkResults[i].Embedding = outputs[i]
+				}
+			}
+			if err != nil {
+				b.logger.Error("Post-tower inference failed for chunk of %d posts: %v", len(chunk), err)
+			}
+			// Always return nil so a failed chunk never cancels the others
+			return nil
+		})
+	}
+
+	_ = group.Wait() // goroutines never return errors
+	return results
+}

--- a/ingest/internal/inference/batch.go
+++ b/ingest/internal/inference/batch.go
@@ -16,10 +16,11 @@ type PostEmbeddingInput struct {
 }
 
 // PostEmbeddingResult is the outcome for a single input. Embedding is nil and
-// Err is set when the input's chunk failed.
+// Err is set when the input's chunk failed. ModelUUID is empty on failure.
 type PostEmbeddingResult struct {
 	AtURI     string
 	Embedding []float32
+	ModelUUID string
 	Err       error
 }
 
@@ -76,13 +77,14 @@ func (b *BatchEmbedder) ComputePostEmbeddings(ctx context.Context, inputs []Post
 				authorDIDs[i] = input.AuthorDID
 			}
 
-			outputs, err := b.client.PostTowerPredict(ctx, embeddings, authorDIDs)
+			outputs, modelUUID, err := b.client.PostTowerPredict(ctx, embeddings, authorDIDs)
 			for i, input := range chunk {
 				chunkResults[i].AtURI = input.AtURI
 				if err != nil {
 					chunkResults[i].Err = err
 				} else {
 					chunkResults[i].Embedding = outputs[i]
+					chunkResults[i].ModelUUID = modelUUID
 				}
 			}
 			if err != nil {

--- a/ingest/internal/inference/batch_test.go
+++ b/ingest/internal/inference/batch_test.go
@@ -1,0 +1,204 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/greenearth/ingest/internal/common"
+)
+
+// echoTowerServer returns a mock inference server whose output for each input
+// embedding is [firstValue, firstValue] so results are attributable to inputs.
+// It also tracks total requests and the maximum number of concurrent requests.
+func echoTowerServer(t *testing.T, requests, maxInFlight *atomic.Int32) *httptest.Server {
+	t.Helper()
+	var inFlight atomic.Int32
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		current := inFlight.Add(1)
+		defer inFlight.Add(-1)
+		for {
+			observed := maxInFlight.Load()
+			if current <= observed || maxInFlight.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+
+		var req predictRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		outputs := make([][]float32, len(req.PostEmbeddings))
+		for i, emb := range req.PostEmbeddings {
+			outputs[i] = []float32{emb[0], emb[0]}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"outputs":    outputs,
+			"model_type": "post-tower",
+		})
+	}))
+}
+
+func makeInputs(n int) []PostEmbeddingInput {
+	inputs := make([]PostEmbeddingInput, n)
+	for i := range inputs {
+		inputs[i] = PostEmbeddingInput{
+			AtURI:     fmt.Sprintf("at://did:plc:test/app.bsky.feed.post/%d", i),
+			Embedding: []float32{float32(i), 0.5},
+			AuthorDID: fmt.Sprintf("did:plc:author%d", i),
+		}
+	}
+	return inputs
+}
+
+func TestComputePostEmbeddingsPreservesOrderAcrossChunks(t *testing.T) {
+	var requests, maxInFlight atomic.Int32
+	server := echoTowerServer(t, &requests, &maxInFlight)
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 7, 4, common.NewLogger(false))
+	inputs := makeInputs(100)
+
+	results := embedder.ComputePostEmbeddings(context.Background(), inputs)
+
+	if len(results) != 100 {
+		t.Fatalf("results length = %d, want 100", len(results))
+	}
+	for i, res := range results {
+		if res.Err != nil {
+			t.Fatalf("result %d unexpected error: %v", i, res.Err)
+		}
+		if res.AtURI != inputs[i].AtURI {
+			t.Errorf("result %d AtURI = %q, want %q", i, res.AtURI, inputs[i].AtURI)
+		}
+		if len(res.Embedding) != 2 || res.Embedding[0] != float32(i) {
+			t.Errorf("result %d embedding = %v, want [%d, %d]", i, res.Embedding, i, i)
+		}
+	}
+}
+
+func TestComputePostEmbeddingsChunkingMath(t *testing.T) {
+	var requests, maxInFlight atomic.Int32
+	server := echoTowerServer(t, &requests, &maxInFlight)
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 32, 8, common.NewLogger(false))
+	results := embedder.ComputePostEmbeddings(context.Background(), makeInputs(100))
+
+	if len(results) != 100 {
+		t.Fatalf("results length = %d, want 100", len(results))
+	}
+	if got := requests.Load(); got != 4 {
+		t.Errorf("request count = %d, want 4 (100 inputs / chunk size 32)", got)
+	}
+}
+
+func TestComputePostEmbeddingsConcurrencyBound(t *testing.T) {
+	var requests, maxInFlight atomic.Int32
+	server := echoTowerServer(t, &requests, &maxInFlight)
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 5, 3, common.NewLogger(false))
+	embedder.ComputePostEmbeddings(context.Background(), makeInputs(100))
+
+	if got := requests.Load(); got != 20 {
+		t.Errorf("request count = %d, want 20 (100 inputs / chunk size 5)", got)
+	}
+	if got := maxInFlight.Load(); got > 3 {
+		t.Errorf("max in-flight requests = %d, want <= 3", got)
+	}
+}
+
+func TestComputePostEmbeddingsFailedChunkIsIsolated(t *testing.T) {
+	// Fails any chunk containing an embedding with first value 0 (the first
+	// chunk); other chunks succeed.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req predictRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		if req.PostEmbeddings[0][0] == 0 {
+			http.Error(w, "boom", http.StatusBadRequest)
+			return
+		}
+		outputs := make([][]float32, len(req.PostEmbeddings))
+		for i, emb := range req.PostEmbeddings {
+			outputs[i] = []float32{emb[0], emb[0]}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"outputs":    outputs,
+			"model_type": "post-tower",
+		})
+	}))
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 10, 4, common.NewLogger(false))
+	results := embedder.ComputePostEmbeddings(context.Background(), makeInputs(30))
+
+	if len(results) != 30 {
+		t.Fatalf("results length = %d, want 30", len(results))
+	}
+	for i, res := range results {
+		if i < 10 {
+			if res.Err == nil {
+				t.Errorf("result %d Err = nil, want error (failed chunk)", i)
+			}
+			if res.Embedding != nil {
+				t.Errorf("result %d embedding = %v, want nil (failed chunk)", i, res.Embedding)
+			}
+		} else {
+			if res.Err != nil {
+				t.Errorf("result %d unexpected error: %v", i, res.Err)
+			}
+			if len(res.Embedding) != 2 {
+				t.Errorf("result %d embedding = %v, want 2 values", i, res.Embedding)
+			}
+		}
+	}
+}
+
+func TestComputePostEmbeddingsEmptyInput(t *testing.T) {
+	var requests, maxInFlight atomic.Int32
+	server := echoTowerServer(t, &requests, &maxInFlight)
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 32, 8, common.NewLogger(false))
+	results := embedder.ComputePostEmbeddings(context.Background(), nil)
+
+	if len(results) != 0 {
+		t.Errorf("results length = %d, want 0", len(results))
+	}
+	if got := requests.Load(); got != 0 {
+		t.Errorf("request count = %d, want 0", got)
+	}
+}
+
+func TestComputePostEmbeddingsCancelledContext(t *testing.T) {
+	var requests, maxInFlight atomic.Int32
+	server := echoTowerServer(t, &requests, &maxInFlight)
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 10, 4, common.NewLogger(false))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results := embedder.ComputePostEmbeddings(ctx, makeInputs(30))
+
+	if len(results) != 30 {
+		t.Fatalf("results length = %d, want 30", len(results))
+	}
+	for i, res := range results {
+		if res.Err == nil {
+			t.Errorf("result %d Err = nil, want context error", i)
+		}
+	}
+}

--- a/ingest/internal/inference/batch_test.go
+++ b/ingest/internal/inference/batch_test.go
@@ -43,6 +43,7 @@ func echoTowerServer(t *testing.T, requests, maxInFlight *atomic.Int32) *httptes
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"outputs":    outputs,
 			"model_type": "post-tower",
+			"model_uuid": "test-uuid-echo",
 		})
 	}))
 }
@@ -162,6 +163,46 @@ func TestComputePostEmbeddingsFailedChunkIsIsolated(t *testing.T) {
 			if len(res.Embedding) != 2 {
 				t.Errorf("result %d embedding = %v, want 2 values", i, res.Embedding)
 			}
+		}
+	}
+}
+
+func TestComputePostEmbeddingsModelUUID(t *testing.T) {
+	var requests, maxInFlight atomic.Int32
+	server := echoTowerServer(t, &requests, &maxInFlight)
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 10, 4, common.NewLogger(false))
+	results := embedder.ComputePostEmbeddings(context.Background(), makeInputs(10))
+
+	if len(results) != 10 {
+		t.Fatalf("results length = %d, want 10", len(results))
+	}
+	for i, res := range results {
+		if res.Err != nil {
+			t.Fatalf("result %d unexpected error: %v", i, res.Err)
+		}
+		if res.ModelUUID != "test-uuid-echo" {
+			t.Errorf("result %d ModelUUID = %q, want %q", i, res.ModelUUID, "test-uuid-echo")
+		}
+	}
+}
+
+func TestComputePostEmbeddingsModelUUIDEmptyOnError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 10, 1, common.NewLogger(false))
+	results := embedder.ComputePostEmbeddings(context.Background(), makeInputs(5))
+
+	for i, res := range results {
+		if res.Err == nil {
+			t.Errorf("result %d Err = nil, want error", i)
+		}
+		if res.ModelUUID != "" {
+			t.Errorf("result %d ModelUUID = %q, want empty on error", i, res.ModelUUID)
 		}
 	}
 }

--- a/ingest/internal/inference/client.go
+++ b/ingest/internal/inference/client.go
@@ -1,0 +1,159 @@
+// Package inference provides a client for the Green Earth inference service
+// and utilities for computing post-tower embeddings during ingestion. It is
+// shared between ingest services so the post embedding pipeline can migrate
+// from megastream_ingest to jetstream_ingest without changes.
+package inference
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/greenearth/ingest/internal/common"
+)
+
+const postTowerPredictPath = "/models/post-tower/predict"
+
+// ClientConfig configures the inference service client
+type ClientConfig struct {
+	BaseURL        string        // e.g. https://inference-stage.greenearth.social; empty disables the client
+	APIKey         string        // sent as the X-API-Key header
+	Timeout        time.Duration // per-request HTTP timeout
+	MaxRetries     int           // retries beyond the first attempt
+	RetryBaseDelay time.Duration // base delay for exponential backoff
+}
+
+// Client is an HTTP client for the inference service. Construct one per
+// process with NewClient and share it; the underlying http.Client pools
+// connections.
+type Client struct {
+	httpClient *http.Client
+	config     ClientConfig
+	logger     *common.IngestLogger
+}
+
+// NewClient creates a new inference service client
+func NewClient(config ClientConfig, logger *common.IngestLogger) *Client {
+	if config.RetryBaseDelay <= 0 {
+		config.RetryBaseDelay = 200 * time.Millisecond
+	}
+	return &Client{
+		httpClient: &http.Client{Timeout: config.Timeout},
+		config:     config,
+		logger:     logger,
+	}
+}
+
+type postTowerRequest struct {
+	PostEmbeddings   [][]float32 `json:"post_embeddings"`
+	TargetAuthorDIDs []string    `json:"target_author_dids"`
+}
+
+type postTowerResponse struct {
+	Outputs   [][]float32 `json:"outputs"`
+	ModelType string      `json:"model_type"`
+}
+
+// PostTowerPredict computes post-tower embeddings for a batch of content
+// embeddings and their author DIDs. Outputs are returned in input order.
+// Retries transport errors, 429s and 5xx responses with exponential backoff;
+// other 4xx responses fail immediately. The batch must not exceed the
+// server's GE_INFERENCE_MAX_BATCH.
+func (c *Client) PostTowerPredict(ctx context.Context, postEmbeddings [][]float32, authorDIDs []string) ([][]float32, error) {
+	if len(postEmbeddings) != len(authorDIDs) {
+		return nil, fmt.Errorf("input length mismatch: %d embeddings vs %d author DIDs", len(postEmbeddings), len(authorDIDs))
+	}
+	if len(postEmbeddings) == 0 {
+		return [][]float32{}, nil
+	}
+
+	body, err := json.Marshal(postTowerRequest{
+		PostEmbeddings:   postEmbeddings,
+		TargetAuthorDIDs: authorDIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	start := time.Now()
+	c.logger.Metric("inference.request.count", 1)
+
+	outputs, err := c.doWithRetries(ctx, body)
+	c.logger.Metric("inference.request.duration_ms", float64(time.Since(start).Milliseconds()))
+	if err != nil {
+		c.logger.Metric("inference.request.errors", 1)
+		return nil, err
+	}
+
+	if len(outputs) != len(postEmbeddings) {
+		c.logger.Metric("inference.request.errors", 1)
+		return nil, fmt.Errorf("output count mismatch: got %d outputs for %d inputs", len(outputs), len(postEmbeddings))
+	}
+
+	return outputs, nil
+}
+
+// doWithRetries performs the HTTP request, retrying retryable failures with
+// exponential backoff and jitter
+func (c *Client) doWithRetries(ctx context.Context, body []byte) ([][]float32, error) {
+	var lastErr error
+	for attempt := 0; attempt <= c.config.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := c.config.RetryBaseDelay * (1 << (attempt - 1))
+			jitter := time.Duration(rand.Int63n(int64(delay) + 1)) //nolint:gosec // G404: jitter does not need crypto randomness
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay + jitter):
+			}
+		}
+
+		outputs, retryable, err := c.doOnce(ctx, body)
+		if err == nil {
+			return outputs, nil
+		}
+		lastErr = err
+		if !retryable {
+			return nil, err
+		}
+		c.logger.Debug("Inference request attempt %d failed (retryable): %v", attempt+1, err)
+	}
+	return nil, fmt.Errorf("inference request failed after %d attempts: %w", c.config.MaxRetries+1, lastErr)
+}
+
+// doOnce performs a single HTTP request. The second return value indicates
+// whether the failure is retryable.
+func (c *Client) doOnce(ctx context.Context, body []byte) ([][]float32, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.config.BaseURL+postTowerPredictPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", c.config.APIKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, ctx.Err() == nil, fmt.Errorf("inference request failed: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close() // Ignore error in cleanup
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		retryable := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
+		return nil, retryable, fmt.Errorf("inference service returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed postTowerResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, false, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return parsed.Outputs, false, nil
+}

--- a/ingest/internal/inference/client.go
+++ b/ingest/internal/inference/client.go
@@ -57,19 +57,21 @@ type postTowerRequest struct {
 type postTowerResponse struct {
 	Outputs   [][]float32 `json:"outputs"`
 	ModelType string      `json:"model_type"`
+	ModelUUID string      `json:"model_uuid"`
 }
 
 // PostTowerPredict computes post-tower embeddings for a batch of content
 // embeddings and their author DIDs. Outputs are returned in input order.
+// The second return value is the model UUID from the inference service response.
 // Retries transport errors, 429s and 5xx responses with exponential backoff;
 // other 4xx responses fail immediately. The batch must not exceed the
 // server's GE_INFERENCE_MAX_BATCH.
-func (c *Client) PostTowerPredict(ctx context.Context, postEmbeddings [][]float32, authorDIDs []string) ([][]float32, error) {
+func (c *Client) PostTowerPredict(ctx context.Context, postEmbeddings [][]float32, authorDIDs []string) ([][]float32, string, error) {
 	if len(postEmbeddings) != len(authorDIDs) {
-		return nil, fmt.Errorf("input length mismatch: %d embeddings vs %d author DIDs", len(postEmbeddings), len(authorDIDs))
+		return nil, "", fmt.Errorf("input length mismatch: %d embeddings vs %d author DIDs", len(postEmbeddings), len(authorDIDs))
 	}
 	if len(postEmbeddings) == 0 {
-		return [][]float32{}, nil
+		return [][]float32{}, "", nil
 	}
 
 	body, err := json.Marshal(postTowerRequest{
@@ -77,30 +79,30 @@ func (c *Client) PostTowerPredict(ctx context.Context, postEmbeddings [][]float3
 		TargetAuthorDIDs: authorDIDs,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
 	start := time.Now()
 	c.logger.Metric("inference.request.count", 1)
 
-	outputs, err := c.doWithRetries(ctx, body)
+	outputs, modelUUID, err := c.doWithRetries(ctx, body)
 	c.logger.Metric("inference.request.duration_ms", float64(time.Since(start).Milliseconds()))
 	if err != nil {
 		c.logger.Metric("inference.request.errors", 1)
-		return nil, err
+		return nil, "", err
 	}
 
 	if len(outputs) != len(postEmbeddings) {
 		c.logger.Metric("inference.request.errors", 1)
-		return nil, fmt.Errorf("output count mismatch: got %d outputs for %d inputs", len(outputs), len(postEmbeddings))
+		return nil, "", fmt.Errorf("output count mismatch: got %d outputs for %d inputs", len(outputs), len(postEmbeddings))
 	}
 
-	return outputs, nil
+	return outputs, modelUUID, nil
 }
 
 // doWithRetries performs the HTTP request, retrying retryable failures with
 // exponential backoff and jitter
-func (c *Client) doWithRetries(ctx context.Context, body []byte) ([][]float32, error) {
+func (c *Client) doWithRetries(ctx context.Context, body []byte) ([][]float32, string, error) {
 	var lastErr error
 	for attempt := 0; attempt <= c.config.MaxRetries; attempt++ {
 		if attempt > 0 {
@@ -108,37 +110,37 @@ func (c *Client) doWithRetries(ctx context.Context, body []byte) ([][]float32, e
 			jitter := time.Duration(rand.Int63n(int64(delay) + 1)) //nolint:gosec // G404: jitter does not need crypto randomness
 			select {
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return nil, "", ctx.Err()
 			case <-time.After(delay + jitter):
 			}
 		}
 
-		outputs, retryable, err := c.doOnce(ctx, body)
+		outputs, modelUUID, retryable, err := c.doOnce(ctx, body)
 		if err == nil {
-			return outputs, nil
+			return outputs, modelUUID, nil
 		}
 		lastErr = err
 		if !retryable {
-			return nil, err
+			return nil, "", err
 		}
 		c.logger.Debug("Inference request attempt %d failed (retryable): %v", attempt+1, err)
 	}
-	return nil, fmt.Errorf("inference request failed after %d attempts: %w", c.config.MaxRetries+1, lastErr)
+	return nil, "", fmt.Errorf("inference request failed after %d attempts: %w", c.config.MaxRetries+1, lastErr)
 }
 
-// doOnce performs a single HTTP request. The second return value indicates
+// doOnce performs a single HTTP request. The third return value indicates
 // whether the failure is retryable.
-func (c *Client) doOnce(ctx context.Context, body []byte) ([][]float32, bool, error) {
+func (c *Client) doOnce(ctx context.Context, body []byte) ([][]float32, string, bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.config.BaseURL+postTowerPredictPath, bytes.NewReader(body))
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to create request: %w", err)
+		return nil, "", false, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", c.config.APIKey)
 
 	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: BaseURL comes from service configuration, not user input
 	if err != nil {
-		return nil, ctx.Err() == nil, fmt.Errorf("inference request failed: %w", err)
+		return nil, "", ctx.Err() == nil, fmt.Errorf("inference request failed: %w", err)
 	}
 	defer func() {
 		_ = resp.Body.Close() // Ignore error in cleanup
@@ -147,13 +149,13 @@ func (c *Client) doOnce(ctx context.Context, body []byte) ([][]float32, bool, er
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 		retryable := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
-		return nil, retryable, fmt.Errorf("inference service returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, "", retryable, fmt.Errorf("inference service returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	var parsed postTowerResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-		return nil, false, fmt.Errorf("failed to decode response: %w", err)
+		return nil, "", false, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return parsed.Outputs, false, nil
+	return parsed.Outputs, parsed.ModelUUID, false, nil
 }

--- a/ingest/internal/inference/client.go
+++ b/ingest/internal/inference/client.go
@@ -22,7 +22,7 @@ const postTowerPredictPath = "/models/post-tower/predict"
 // ClientConfig configures the inference service client
 type ClientConfig struct {
 	BaseURL        string        // e.g. https://inference-stage.greenearth.social; empty disables the client
-	APIKey         string        // sent as the X-API-Key header
+	APIKey         string //nolint:gosec // G117: struct field name, not a secret value; sent as the X-API-Key header
 	Timeout        time.Duration // per-request HTTP timeout
 	MaxRetries     int           // retries beyond the first attempt
 	RetryBaseDelay time.Duration // base delay for exponential backoff
@@ -136,7 +136,7 @@ func (c *Client) doOnce(ctx context.Context, body []byte) ([][]float32, bool, er
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", c.config.APIKey)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: BaseURL comes from service configuration, not user input
 	if err != nil {
 		return nil, ctx.Err() == nil, fmt.Errorf("inference request failed: %w", err)
 	}

--- a/ingest/internal/inference/client_test.go
+++ b/ingest/internal/inference/client_test.go
@@ -1,0 +1,262 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/greenearth/ingest/internal/common"
+)
+
+func testClient(baseURL string, maxRetries int) *Client {
+	return NewClient(ClientConfig{
+		BaseURL:        baseURL,
+		APIKey:         "test-key",
+		Timeout:        2 * time.Second,
+		MaxRetries:     maxRetries,
+		RetryBaseDelay: time.Millisecond,
+	}, common.NewLogger(false))
+}
+
+type predictRequest struct {
+	PostEmbeddings   [][]float32 `json:"post_embeddings"`
+	TargetAuthorDIDs []string    `json:"target_author_dids"`
+}
+
+func TestPostTowerPredictSuccess(t *testing.T) {
+	var gotPath, gotAPIKey, gotContentType string
+	var gotBody predictRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("X-API-Key")
+		gotContentType = r.Header.Get("Content-Type")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		outputs := make([][]float32, len(gotBody.PostEmbeddings))
+		for i := range outputs {
+			outputs[i] = []float32{float32(i), float32(i) + 0.5}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"outputs":    outputs,
+			"model_type": "post-tower",
+		})
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 0)
+	inputs := [][]float32{{0.1, 0.2}, {0.3, 0.4}}
+	dids := []string{"did:plc:aaa", "did:plc:bbb"}
+
+	outputs, err := client.PostTowerPredict(context.Background(), inputs, dids)
+	if err != nil {
+		t.Fatalf("PostTowerPredict() error = %v, expected nil", err)
+	}
+
+	if gotPath != "/models/post-tower/predict" {
+		t.Errorf("path = %q, want /models/post-tower/predict", gotPath)
+	}
+	if gotAPIKey != "test-key" {
+		t.Errorf("X-API-Key = %q, want test-key", gotAPIKey)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if len(gotBody.PostEmbeddings) != 2 || len(gotBody.TargetAuthorDIDs) != 2 {
+		t.Fatalf("request body lengths = %d/%d, want 2/2", len(gotBody.PostEmbeddings), len(gotBody.TargetAuthorDIDs))
+	}
+	if gotBody.TargetAuthorDIDs[0] != "did:plc:aaa" || gotBody.TargetAuthorDIDs[1] != "did:plc:bbb" {
+		t.Errorf("target_author_dids = %v", gotBody.TargetAuthorDIDs)
+	}
+	if len(outputs) != 2 {
+		t.Fatalf("outputs length = %d, want 2", len(outputs))
+	}
+	if outputs[0][0] != 0 || outputs[0][1] != 0.5 || outputs[1][0] != 1 || outputs[1][1] != 1.5 {
+		t.Errorf("outputs = %v, order not preserved", outputs)
+	}
+}
+
+func TestPostTowerPredictBadRequestNoRetry(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, `{"detail":"batch too large (max=1024)"}`, http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 3)
+	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	if err == nil {
+		t.Fatal("PostTowerPredict() error = nil, expected error")
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("request count = %d, want 1 (4xx must not retry)", got)
+	}
+}
+
+func TestPostTowerPredictRetriesServerError(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"outputs":    [][]float32{{1.0}},
+			"model_type": "post-tower",
+		})
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 3)
+	outputs, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	if err != nil {
+		t.Fatalf("PostTowerPredict() error = %v, expected nil after retry", err)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Errorf("request count = %d, want 2 (500 then 200)", got)
+	}
+	if len(outputs) != 1 || outputs[0][0] != 1.0 {
+		t.Errorf("outputs = %v, want [[1.0]]", outputs)
+	}
+}
+
+func TestPostTowerPredictRetriesExhausted(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 2)
+	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	if err == nil {
+		t.Fatal("PostTowerPredict() error = nil, expected error after exhausted retries")
+	}
+	if got := requests.Load(); got != 3 {
+		t.Errorf("request count = %d, want 3 (1 initial + 2 retries)", got)
+	}
+}
+
+func TestPostTowerPredictRetriesTooManyRequests(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"outputs":    [][]float32{{1.0}},
+			"model_type": "post-tower",
+		})
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 3)
+	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	if err != nil {
+		t.Fatalf("PostTowerPredict() error = %v, expected nil after 429 retry", err)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Errorf("request count = %d, want 2 (429 then 200)", got)
+	}
+}
+
+func TestPostTowerPredictOutputCountMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"outputs":    [][]float32{{1.0}},
+			"model_type": "post-tower",
+		})
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 0)
+	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}, {0.2}}, []string{"did:plc:a", "did:plc:b"})
+	if err == nil {
+		t.Fatal("PostTowerPredict() error = nil, expected output count mismatch error")
+	}
+}
+
+func TestPostTowerPredictInputLengthMismatch(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 0)
+	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a", "did:plc:b"})
+	if err == nil {
+		t.Fatal("PostTowerPredict() error = nil, expected input length mismatch error")
+	}
+	if got := requests.Load(); got != 0 {
+		t.Errorf("request count = %d, want 0 (validation happens before any call)", got)
+	}
+}
+
+func TestPostTowerPredictEmptyInput(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 0)
+	outputs, err := client.PostTowerPredict(context.Background(), [][]float32{}, []string{})
+	if err != nil {
+		t.Fatalf("PostTowerPredict() error = %v, expected nil for empty input", err)
+	}
+	if len(outputs) != 0 {
+		t.Errorf("outputs length = %d, want 0", len(outputs))
+	}
+	if got := requests.Load(); got != 0 {
+		t.Errorf("request count = %d, want 0 (empty input makes no call)", got)
+	}
+}
+
+func TestPostTowerPredictTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	client := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		APIKey:         "test-key",
+		Timeout:        20 * time.Millisecond,
+		MaxRetries:     0,
+		RetryBaseDelay: time.Millisecond,
+	}, common.NewLogger(false))
+
+	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	if err == nil {
+		t.Fatal("PostTowerPredict() error = nil, expected timeout error")
+	}
+}
+
+func TestPostTowerPredictContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 3)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.PostTowerPredict(ctx, [][]float32{{0.1}}, []string{"did:plc:a"})
+	if err == nil {
+		t.Fatal("PostTowerPredict() error = nil, expected context cancellation error")
+	}
+}

--- a/ingest/internal/inference/client_test.go
+++ b/ingest/internal/inference/client_test.go
@@ -54,7 +54,7 @@ func TestPostTowerPredictSuccess(t *testing.T) {
 	inputs := [][]float32{{0.1, 0.2}, {0.3, 0.4}}
 	dids := []string{"did:plc:aaa", "did:plc:bbb"}
 
-	outputs, err := client.PostTowerPredict(context.Background(), inputs, dids)
+	outputs, _, err := client.PostTowerPredict(context.Background(), inputs, dids)
 	if err != nil {
 		t.Fatalf("PostTowerPredict() error = %v, expected nil", err)
 	}
@@ -82,6 +82,27 @@ func TestPostTowerPredictSuccess(t *testing.T) {
 	}
 }
 
+func TestPostTowerPredictReturnsModelUUID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"outputs":    [][]float32{{1.0}},
+			"model_type": "post-tower",
+			"model_uuid": "test-uuid-abc",
+		})
+	}))
+	defer server.Close()
+
+	client := testClient(server.URL, 0)
+	_, uuid, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	if err != nil {
+		t.Fatalf("PostTowerPredict() error = %v, expected nil", err)
+	}
+	if uuid != "test-uuid-abc" {
+		t.Errorf("model_uuid = %q, want %q", uuid, "test-uuid-abc")
+	}
+}
+
 func TestPostTowerPredictBadRequestNoRetry(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -91,7 +112,7 @@ func TestPostTowerPredictBadRequestNoRetry(t *testing.T) {
 	defer server.Close()
 
 	client := testClient(server.URL, 3)
-	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	_, _, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
 	if err == nil {
 		t.Fatal("PostTowerPredict() error = nil, expected error")
 	}
@@ -116,7 +137,7 @@ func TestPostTowerPredictRetriesServerError(t *testing.T) {
 	defer server.Close()
 
 	client := testClient(server.URL, 3)
-	outputs, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	outputs, _, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
 	if err != nil {
 		t.Fatalf("PostTowerPredict() error = %v, expected nil after retry", err)
 	}
@@ -137,7 +158,7 @@ func TestPostTowerPredictRetriesExhausted(t *testing.T) {
 	defer server.Close()
 
 	client := testClient(server.URL, 2)
-	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	_, _, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
 	if err == nil {
 		t.Fatal("PostTowerPredict() error = nil, expected error after exhausted retries")
 	}
@@ -162,7 +183,7 @@ func TestPostTowerPredictRetriesTooManyRequests(t *testing.T) {
 	defer server.Close()
 
 	client := testClient(server.URL, 3)
-	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	_, _, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
 	if err != nil {
 		t.Fatalf("PostTowerPredict() error = %v, expected nil after 429 retry", err)
 	}
@@ -182,7 +203,7 @@ func TestPostTowerPredictOutputCountMismatch(t *testing.T) {
 	defer server.Close()
 
 	client := testClient(server.URL, 0)
-	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}, {0.2}}, []string{"did:plc:a", "did:plc:b"})
+	_, _, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}, {0.2}}, []string{"did:plc:a", "did:plc:b"})
 	if err == nil {
 		t.Fatal("PostTowerPredict() error = nil, expected output count mismatch error")
 	}
@@ -196,7 +217,7 @@ func TestPostTowerPredictInputLengthMismatch(t *testing.T) {
 	defer server.Close()
 
 	client := testClient(server.URL, 0)
-	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a", "did:plc:b"})
+	_, _, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a", "did:plc:b"})
 	if err == nil {
 		t.Fatal("PostTowerPredict() error = nil, expected input length mismatch error")
 	}
@@ -213,7 +234,7 @@ func TestPostTowerPredictEmptyInput(t *testing.T) {
 	defer server.Close()
 
 	client := testClient(server.URL, 0)
-	outputs, err := client.PostTowerPredict(context.Background(), [][]float32{}, []string{})
+	outputs, _, err := client.PostTowerPredict(context.Background(), [][]float32{}, []string{})
 	if err != nil {
 		t.Fatalf("PostTowerPredict() error = %v, expected nil for empty input", err)
 	}
@@ -239,7 +260,7 @@ func TestPostTowerPredictTimeout(t *testing.T) {
 		RetryBaseDelay: time.Millisecond,
 	}, common.NewLogger(false))
 
-	_, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
+	_, _, err := client.PostTowerPredict(context.Background(), [][]float32{{0.1}}, []string{"did:plc:a"})
 	if err == nil {
 		t.Fatal("PostTowerPredict() error = nil, expected timeout error")
 	}
@@ -255,7 +276,7 @@ func TestPostTowerPredictContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := client.PostTowerPredict(ctx, [][]float32{{0.1}}, []string{"did:plc:a"})
+	_, _, err := client.PostTowerPredict(ctx, [][]float32{{0.1}}, []string{"did:plc:a"})
 	if err == nil {
 		t.Fatal("PostTowerPredict() error = nil, expected context cancellation error")
 	}

--- a/ingest/internal/inference/docs.go
+++ b/ingest/internal/inference/docs.go
@@ -46,6 +46,7 @@ func AttachPostTowerEmbeddings(ctx context.Context, b *BatchEmbedder, docs []com
 			continue
 		}
 		docs[eligible[j]].Embeddings[postEmbeddingKey] = result.Embedding
+		docs[eligible[j]].PostEmbeddingModelUUID = result.ModelUUID
 		embedded++
 	}
 

--- a/ingest/internal/inference/docs.go
+++ b/ingest/internal/inference/docs.go
@@ -1,0 +1,57 @@
+package inference
+
+import (
+	"context"
+
+	"github.com/greenearth/ingest/internal/common"
+)
+
+const (
+	// contentEmbeddingKey is the post content embedding used as post-tower input
+	contentEmbeddingKey = "all_MiniLM_L12_v2"
+	// postEmbeddingKey is the ES embeddings field the post-tower output is stored under
+	postEmbeddingKey = "ge_post_embedding"
+)
+
+// AttachPostTowerEmbeddings computes post-tower embeddings for eligible docs
+// and sets doc.Embeddings["ge_post_embedding"] in place. A doc is eligible
+// when it is not a reply (ThreadParentPost is empty) and has a content
+// embedding. Fail-open: docs whose inference chunk failed are left without
+// the field so they still index. No-op when b is nil (disabled / dry-run).
+func AttachPostTowerEmbeddings(ctx context.Context, b *BatchEmbedder, docs []common.ElasticsearchDoc) (embedded, skipped, failed int) {
+	if b == nil || len(docs) == 0 {
+		return 0, 0, 0
+	}
+
+	inputs := make([]PostEmbeddingInput, 0, len(docs))
+	eligible := make([]int, 0, len(docs))
+	for i, doc := range docs {
+		contentEmbedding, ok := doc.Embeddings[contentEmbeddingKey]
+		if doc.ThreadParentPost != "" || !ok {
+			skipped++
+			continue
+		}
+		inputs = append(inputs, PostEmbeddingInput{
+			AtURI:     doc.AtURI,
+			Embedding: contentEmbedding,
+			AuthorDID: doc.AuthorDID,
+		})
+		eligible = append(eligible, i)
+	}
+
+	results := b.ComputePostEmbeddings(ctx, inputs)
+	for j, result := range results {
+		if result.Err != nil {
+			failed++
+			continue
+		}
+		docs[eligible[j]].Embeddings[postEmbeddingKey] = result.Embedding
+		embedded++
+	}
+
+	b.logger.Metric("posts.post_tower.embedded.count", float64(embedded))
+	b.logger.Metric("posts.post_tower.skipped.count", float64(skipped))
+	b.logger.Metric("posts.post_tower.failed.count", float64(failed))
+
+	return embedded, skipped, failed
+}

--- a/ingest/internal/inference/docs_test.go
+++ b/ingest/internal/inference/docs_test.go
@@ -1,0 +1,122 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/greenearth/ingest/internal/common"
+)
+
+func makeDoc(atURI, authorDID, threadParentPost string, contentEmbedding []float32) common.ElasticsearchDoc {
+	doc := common.ElasticsearchDoc{
+		AtURI:            atURI,
+		AuthorDID:        authorDID,
+		ThreadParentPost: threadParentPost,
+	}
+	if contentEmbedding != nil {
+		doc.Embeddings = map[string]common.Float32Array{
+			contentEmbeddingKey: contentEmbedding,
+		}
+	}
+	return doc
+}
+
+func TestAttachPostTowerEmbeddings(t *testing.T) {
+	var requests, maxInFlight atomic.Int32
+	server := echoTowerServer(t, &requests, &maxInFlight)
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 32, 4, common.NewLogger(false))
+
+	docs := []common.ElasticsearchDoc{
+		makeDoc("at://a/post/1", "did:plc:a", "", []float32{1.0, 0.5}),
+		makeDoc("at://a/post/2", "did:plc:a", "at://parent/post/0", []float32{2.0, 0.5}), // reply: skipped
+		makeDoc("at://a/post/3", "did:plc:b", "", nil),                                   // no content embedding: skipped
+		makeDoc("at://a/post/4", "did:plc:b", "", []float32{4.0, 0.5}),
+	}
+
+	embedded, skipped, failed := AttachPostTowerEmbeddings(context.Background(), embedder, docs)
+
+	if embedded != 2 || skipped != 2 || failed != 0 {
+		t.Errorf("counts = (%d, %d, %d), want (2, 2, 0)", embedded, skipped, failed)
+	}
+
+	if got := docs[0].Embeddings[postEmbeddingKey]; len(got) != 2 || got[0] != 1.0 {
+		t.Errorf("doc 0 %s = %v, want [1.0, 1.0]", postEmbeddingKey, got)
+	}
+	if _, ok := docs[1].Embeddings[postEmbeddingKey]; ok {
+		t.Errorf("doc 1 is a reply, must not have %s", postEmbeddingKey)
+	}
+	if _, ok := docs[2].Embeddings[postEmbeddingKey]; ok {
+		t.Errorf("doc 2 has no content embedding, must not have %s", postEmbeddingKey)
+	}
+	if got := docs[3].Embeddings[postEmbeddingKey]; len(got) != 2 || got[0] != 4.0 {
+		t.Errorf("doc 3 %s = %v, want [4.0, 4.0]", postEmbeddingKey, got)
+	}
+
+	// Content embeddings must be preserved
+	if got := docs[0].Embeddings[contentEmbeddingKey]; len(got) != 2 || got[0] != 1.0 {
+		t.Errorf("doc 0 content embedding was clobbered: %v", got)
+	}
+}
+
+func TestAttachPostTowerEmbeddingsNilEmbedder(t *testing.T) {
+	docs := []common.ElasticsearchDoc{
+		makeDoc("at://a/post/1", "did:plc:a", "", []float32{1.0, 0.5}),
+	}
+
+	embedded, skipped, failed := AttachPostTowerEmbeddings(context.Background(), nil, docs)
+
+	if embedded != 0 || skipped != 0 || failed != 0 {
+		t.Errorf("counts = (%d, %d, %d), want (0, 0, 0) for nil embedder", embedded, skipped, failed)
+	}
+	if _, ok := docs[0].Embeddings[postEmbeddingKey]; ok {
+		t.Errorf("nil embedder must not attach embeddings")
+	}
+}
+
+func TestAttachPostTowerEmbeddingsEmptyDocs(t *testing.T) {
+	var requests, maxInFlight atomic.Int32
+	server := echoTowerServer(t, &requests, &maxInFlight)
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 32, 4, common.NewLogger(false))
+	embedded, skipped, failed := AttachPostTowerEmbeddings(context.Background(), embedder, nil)
+
+	if embedded != 0 || skipped != 0 || failed != 0 {
+		t.Errorf("counts = (%d, %d, %d), want (0, 0, 0)", embedded, skipped, failed)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Errorf("request count = %d, want 0", got)
+	}
+}
+
+func TestAttachPostTowerEmbeddingsFailOpen(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	embedder := NewBatchEmbedder(testClient(server.URL, 0), 32, 4, common.NewLogger(false))
+	docs := []common.ElasticsearchDoc{
+		makeDoc("at://a/post/1", "did:plc:a", "", []float32{1.0, 0.5}),
+		makeDoc("at://a/post/2", "did:plc:a", "at://parent/post/0", []float32{2.0, 0.5}),
+	}
+
+	embedded, skipped, failed := AttachPostTowerEmbeddings(context.Background(), embedder, docs)
+
+	if embedded != 0 || skipped != 1 || failed != 1 {
+		t.Errorf("counts = (%d, %d, %d), want (0, 1, 1)", embedded, skipped, failed)
+	}
+	if _, ok := docs[0].Embeddings[postEmbeddingKey]; ok {
+		t.Errorf("failed doc must not have %s", postEmbeddingKey)
+	}
+	// Doc must still be marshalable/indexable without the post embedding
+	if _, err := json.Marshal(docs[0]); err != nil {
+		t.Errorf("doc 0 not marshalable after failure: %v", err)
+	}
+}

--- a/ingest/internal/inference/docs_test.go
+++ b/ingest/internal/inference/docs_test.go
@@ -62,6 +62,20 @@ func TestAttachPostTowerEmbeddings(t *testing.T) {
 	if got := docs[0].Embeddings[contentEmbeddingKey]; len(got) != 2 || got[0] != 1.0 {
 		t.Errorf("doc 0 content embedding was clobbered: %v", got)
 	}
+
+	// Model UUID must be set on eligible docs and empty on skipped ones
+	if docs[0].PostEmbeddingModelUUID != "test-uuid-echo" {
+		t.Errorf("doc 0 PostEmbeddingModelUUID = %q, want %q", docs[0].PostEmbeddingModelUUID, "test-uuid-echo")
+	}
+	if docs[1].PostEmbeddingModelUUID != "" {
+		t.Errorf("doc 1 (reply) PostEmbeddingModelUUID = %q, want empty", docs[1].PostEmbeddingModelUUID)
+	}
+	if docs[2].PostEmbeddingModelUUID != "" {
+		t.Errorf("doc 2 (no content embedding) PostEmbeddingModelUUID = %q, want empty", docs[2].PostEmbeddingModelUUID)
+	}
+	if docs[3].PostEmbeddingModelUUID != "test-uuid-echo" {
+		t.Errorf("doc 3 PostEmbeddingModelUUID = %q, want %q", docs[3].PostEmbeddingModelUUID, "test-uuid-echo")
+	}
 }
 
 func TestAttachPostTowerEmbeddingsNilEmbedder(t *testing.T) {
@@ -118,5 +132,8 @@ func TestAttachPostTowerEmbeddingsFailOpen(t *testing.T) {
 	// Doc must still be marshalable/indexable without the post embedding
 	if _, err := json.Marshal(docs[0]); err != nil {
 		t.Errorf("doc 0 not marshalable after failure: %v", err)
+	}
+	if docs[0].PostEmbeddingModelUUID != "" {
+		t.Errorf("failed doc PostEmbeddingModelUUID = %q, want empty", docs[0].PostEmbeddingModelUUID)
 	}
 }

--- a/ingest/scripts/deploy.sh
+++ b/ingest/scripts/deploy.sh
@@ -243,6 +243,18 @@ deploy_megastream_service() {
         aws_secret_key_secret="aws-s3-secret-key-prod"
     fi
 
+    # Inference service for post-tower embeddings (secrets managed by the
+    # inference-service repo). NOTE: the ge_post_embedding dense_vector mapping
+    # must be deployed to the posts index (index/deploy.sh <env> --ctypes schema)
+    # before this service writes the field, or ES will dynamically map it as a
+    # plain float field that cannot serve kNN queries.
+    local inference_api_key_secret="inference-api-key-$GE_ENVIRONMENT"
+    local inference_base_url="https://inference-stage.greenearth.social"
+    if [ "$GE_ENVIRONMENT" = "prod" ]; then
+        inference_base_url="https://inference.greenearth.social"
+    fi
+    inference_base_url="${GE_INFERENCE_BASE_URL:-$inference_base_url}"
+
     # Set max-rewind based on environment
     # Stage: 15 minutes (prevent disk overflow on restart)
     # Prod: 0 (unlimited rewind for data integrity)
@@ -274,7 +286,8 @@ deploy_megastream_service() {
         --set-env-vars="GE_AWS_S3_BUCKET=$GE_AWS_S3_BUCKET" \
         --set-env-vars="GE_AWS_S3_PREFIX=$GE_AWS_S3_PREFIX" \
         --set-env-vars="GE_INDEX_PERIOD=$GE_INDEX_PERIOD" \
-        --set-secrets="GE_ELASTICSEARCH_API_KEY=$es_api_key_secret:latest,GE_AWS_S3_ACCESS_KEY=$aws_access_key_secret:latest,GE_AWS_S3_SECRET_KEY=$aws_secret_key_secret:latest" \
+        --set-env-vars="GE_INFERENCE_BASE_URL=$inference_base_url" \
+        --set-secrets="GE_ELASTICSEARCH_API_KEY=$es_api_key_secret:latest,GE_AWS_S3_ACCESS_KEY=$aws_access_key_secret:latest,GE_AWS_S3_SECRET_KEY=$aws_secret_key_secret:latest,GE_INFERENCE_API_KEY=$inference_api_key_secret:latest" \
         --scaling="$GE_MEGASTREAM_INSTANCES" \
         --cpu=1 \
         --memory=1Gi \


### PR DESCRIPTION
Closes #372

Depends on https://github.com/greenearth-social/inference-service/pull/16

Implements post-tower embedding generation during megastream ingest. All new logic lives in shared `internal/inference` and `internal/embeddings` packages so the pipeline can migrate to jetstream_ingest as a post-hydration post-processor when megastream is sunset. The post tower's output dimension was confirmed empirically against the stage inference service (128 dim).

# This PR

- Extract the base85+zlib float32 embedding codec from `internal/common` into a standalone `internal/embeddings` package with exported `Encode`/`Decode`
- Add `internal/inference.Client`: HTTP client for `POST /models/post-tower/predict` with X-API-Key auth, exponential backoff retries on transport errors/429/5xx (no retry on other 4xx), and `inference.request.*` metrics
- Add `internal/inference.BatchEmbedder`: chunked concurrent fan-out via errgroup with bounded concurrency; per-chunk fail-open so one failed chunk never affects others; results in input order
- Add `inference.AttachPostTowerEmbeddings`: attaches 128-dim `embeddings.ge_post_embedding` to eligible docs (non-reply posts with an `all_MiniLM_L12_v2` content embedding); fail-open — posts still index without the field on inference failure; emits `posts.post_tower.*` count metrics
- Wire into megastream_ingest `indexDocuments`; fails at startup if `GE_INFERENCE_BASE_URL` is unset (unless `--dry-run`)
- Add `GE_INFERENCE_*` config vars (base URL, API key, timeout 10s, chunk size 64, max concurrency 8, retries 3)
- Add `ge_post_embedding` dense_vector (dims=128, cosine) and `ge_post_embedding_model_uuid` keyword to the posts index template
- Wire `GE_INFERENCE_BASE_URL` env var and `inference-api-key-{env}` secret into the megastream Cloud Run deploy
- Async 1-deep post-flush pipeline: inference+ES write runs concurrently with the next batch accumulating, so throughput is `max(fill, inference+ES)` instead of their sum; `batchSize` 100→512, `GE_INFERENCE_CHUNK_SIZE` default 1024→64 (8 chunks/batch saturates `max_concurrency=8`)
- Propagate `model_uuid` from inference service predict response (set by inference-service PR #16 via `post_tower_clearml_model_id` from manifest); store as `ge_post_embedding_model_uuid: keyword` on each post doc so kNN queries can filter to a consistent embedding space and stale docs can be detected when the model is retrained

```
Before:  |--fill 100--|--inference+ES--|--fill 100--|--inference+ES--|
After:   |---fill 512---|---fill 512---|---fill 512---|
                        |--inference+ES--|--inference+ES--|
```

# Testing

- TDD throughout: each component's tests written and observed failing before implementation
- Unit tests: `cd ingest && go test -count=1 ./...` — all packages pass (codec round-trips incl. 384-dim; client success/retry/4xx-no-retry/timeout/output-mismatch/model_uuid via httptest; embedder ordering/chunking math/concurrency bound/fail-open isolation/model_uuid propagation; doc attachment eligibility incl. reply + missing-embedding skips + model_uuid on eligible docs; config defaults and env overrides)
- Lint: `cd ingest && golangci-lint run` — 0 issues
- Builds: all four binaries compile clean
- Empirical check: stage inference service `POST /models/post-tower/predict` with a 384-dim input returns a 128-dim output (confirms dims used in the ES mapping)
- Local integration test (fresh minikube ES cluster, stage inference service):
  - Deployed fresh local ES via `index/deploy.sh local --ctypes init --install-eck` then `--ctypes schema` (schema step required to re-run bootstrap job after `init` on an existing cluster)
  - Confirmed `ge_post_embedding` in `posts_ilm_template` as `dense_vector` dims=128 before running ingest
  - Ran `megastream_ingest --source local --mode once --skip-tls-verify` against 3 test `.db.zip` files (15 posts total)
  - Metrics confirmed: `posts.post_tower.embedded.count=15`, `posts.post_tower.failed.count=0`, `inference.request.count=1` (all 15 posts in one chunk), `inference.request.duration_ms=231`
  - Verified all 15 non-reply docs in ES have `embeddings.ge_post_embedding` with 128 elements
  - Verified field type on live index is `dense_vector` (not `float`) — confirms schema was applied before ingest
  - kNN query (`k=3`, `num_candidates=15`) using a real stored embedding as query vector returns 3 results — confirms the field is indexed for similarity search, not just stored

# Deploying to stage

Depends on inference-service PR #16 being deployed first (to expose `model_uuid` in predict responses).

```bash
source .env.stage

# 1. Apply updated index template (must happen before deploying the service)
cd index && ./deploy.sh stage --ctypes schema

# 1.1 Wait for the ES cluster to become READY
kubectl get pods -n $GE_K8S_NAMESPACE -l 'elasticsearch.k8s.elastic.co/cluster-name=greenearth' 2>/dev/null || echo "kubectl not available or namespace not set"

# 2. PUT ge_post_embedding and ge_post_embedding_model_uuid onto the current write index
GE_ELASTICSEARCH_API_KEY=$(gcloud secrets versions access latest --secret="elasticsearch-api-key")
GE_ES_URL='https://localhost:9200'
WRITE_INDEX=$(curl -ks -H "Authorization: ApiKey $GE_ELASTICSEARCH_API_KEY" \
  "$GE_ES_URL/posts/_alias" \
  | jq -r 'to_entries[] | select(.value.aliases.posts.is_write_index==true) | .key')
curl -kX PUT -H "Authorization: ApiKey $GE_ELASTICSEARCH_API_KEY" \
  -H "Content-Type: application/json" \
  "$GE_ES_URL/$WRITE_INDEX/_mapping" \
  -d '{"properties":{"embeddings":{"properties":{"ge_post_embedding":{"type":"dense_vector","dims":128,"index":true,"similarity":"cosine"}}},"ge_post_embedding_model_uuid":{"type":"keyword"}}}'

# 3. Confirm mapping before proceeding (should show dense_vector, not float)
curl -ks -H "Authorization: ApiKey $GE_ELASTICSEARCH_API_KEY" \
  "$GE_ES_URL/$WRITE_INDEX/_mapping" \
  | jq '.[].mappings.properties.embeddings.properties.ge_post_embedding'

# 4. Deploy megastream-ingest (inference vars are already wired in deploy.sh)
cd ingest && ./scripts/deploy.sh  megastream
```

> [!IMPORTANT]
> **Rollout ordering:** deploy the schema first (`index/deploy.sh <env> --ctypes schema`), then PUT the new mapping onto the current write index, and only then deploy megastream-ingest with `GE_INFERENCE_BASE_URL` set. If the service writes `embeddings.ge_post_embedding` before the mapping exists, ES dynamically maps it as plain `float`, which cannot serve kNN queries and requires a reindex to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)