### PR TITLE
fix: route posts with reply_root_uri to replies index

### DIFF
--- a/ingest/cmd/megastream_ingest/main.go
+++ b/ingest/cmd/megastream_ingest/main.go
@@ -533,9 +533,10 @@ cleanup:
 }
 
 // postAliasFromDoc returns the ES alias for a document.
-// Posts with a non-empty thread_parent_post are replies and go to the replies alias.
+// Posts with a non-empty thread_parent_post or thread_root_post are replies
+// and go to the replies alias.
 func postAliasFromDoc(doc common.ElasticsearchDoc) string {
-	if doc.ThreadParentPost != "" {
+	if doc.ThreadParentPost != "" || doc.ThreadRootPost != "" {
 		return "replies"
 	}
 	return "posts"

--- a/ingest/cmd/megastream_ingest/main_test.go
+++ b/ingest/cmd/megastream_ingest/main_test.go
@@ -20,6 +20,24 @@ func TestPostAliasFromDoc_reply(t *testing.T) {
 	}
 }
 
+func TestPostAliasFromDoc_rootOnlyIsReply(t *testing.T) {
+	// thread_root_post set but thread_parent_post empty: Megastream missed parent_post
+	doc := common.ElasticsearchDoc{ThreadRootPost: "at://did:plc:abc/app.bsky.feed.post/root"}
+	if got := postAliasFromDoc(doc); got != "replies" {
+		t.Errorf("expected replies, got %s", got)
+	}
+}
+
+func TestPostAliasFromDoc_bothRootAndParentIsReply(t *testing.T) {
+	doc := common.ElasticsearchDoc{
+		ThreadRootPost:   "at://did:plc:abc/app.bsky.feed.post/root",
+		ThreadParentPost: "at://did:plc:abc/app.bsky.feed.post/parent",
+	}
+	if got := postAliasFromDoc(doc); got != "replies" {
+		t.Errorf("expected replies, got %s", got)
+	}
+}
+
 // TestIndexDocuments_errorHandlingContract documents the intended behavior of indexDocuments:
 // - posts and replies are indexed concurrently via goroutines.
 // - If either batch fails, the error is logged internally with batchContext; no error is returned.


### PR DESCRIPTION
Closes #384 

## This PR

- Extends `postAliasFromDoc` to treat `thread_root_post` as a reply signal, in addition to the existing `thread_parent_post` check
- ~0.6% of replies were being indexed to `posts` because Megastream's `hydrated_metadata` sporadically omits `parent_post` even when `reply_post` (root) is present

## Notes

prod `recent_posts` is updated weekly, so I didn't backfill the misindexed replies in `posts`. Happy to backfill if needed!