### PR TITLE
fix: add replies* to es_service_role index privileges

### DIFF
--- a/index/deploy/k8s/base/es-service-user-setup-job.yaml
+++ b/index/deploy/k8s/base/es-service-user-setup-job.yaml
@@ -48,7 +48,7 @@ spec:
               "cluster": ["manage_index_templates", "monitor", "manage_ilm", "create_snapshot", "manage_slm", "manage"],
               "indices": [
                 {
-                  "names": ["posts*", "post_tombstones*", "post-tombstones*", "likes*", "like_tombstones*", "like-tombstones*", "hashtags*", "inferences*"],
+                  "names": ["posts*", "post_tombstones*", "post-tombstones*", "replies*", "reply_tombstones*", "reply-tombstones*", "likes*", "like_tombstones*", "like-tombstones*", "hashtags*", "inferences*"],
                   "privileges": ["create_index", "manage", "write", "read"]
                 }
               ]


### PR DESCRIPTION
Closes #386

PR #364 introduced the replies index and correctly added `replies_ilm_policy` to the bootstrap job and `replies*` to the SLM snapshot policy, but forgot to add `replies*` and `reply_tombstones*` to the `es_service_role` index pattern list in `es-service-user-setup-job.yaml`. As a result, `es-service-user` had no `read`, `write`, `manage`, or `create_index` privileges on replies indices — making replies indices invisible to `_cat/indices` and preventing ILM from deleting old replies indices through the service user. This caused 273 hourly indices to accumulate in stage from June 8 onward (11 days of unbounded disk growth).

# This PR

- Add `replies*` and `reply_tombstones*` to the `names` array in `es-service-user-setup-job.yaml`

# Testing

## Deploy steps (run after merging)

```
cd index && ./deploy.sh stage --ctypes schema
cd index && ./deploy.sh prod  --ctypes schema
```

## Manual index cleanup in stage (run after deploying)

After schema deploy, es-service-user gains manage on replies-*. Use the elastic superuser to delete the 270+ stale indices:

```bash
ELASTIC_PASS=$(kubectl get secret -n greenearth-stage greenearth-es-elastic-user -o jsonpath='{.data.elastic}' | base64 -d)
POD=$(kubectl get pod -n greenearth-stage -l common.k8s.elastic.co/type=elasticsearch -o jsonpath='{.items[0].metadata.name}')

# Delete pre-today indices (June 8-18)
for DATE in 2026-06-08 2026-06-09 2026-06-10 2026-06-11 2026-06-12 2026-06-13 2026-06-14 2026-06-15 2026-06-16 2026-06-17 2026-06-18; do
  INDICES=$(python3 -c "print(','.join([f'replies-${DATE}-{h:02d}' for h in range(24)]))")
  kubectl exec -n greenearth-stage "$POD" -- curl -sk -X DELETE -u "elastic:$ELASTIC_PASS" "https://greenearth-es-http:9200/$INDICES"
done

# Delete todays stale indices: recalculate cutoff before running
CUTOFF=$(python3 -c "from datetime import datetime,timezone,timedelta; print((datetime.now(timezone.utc)-timedelta(hours=3)).hour)")
for HOUR in $(seq -w 0 $CUTOFF); do
  kubectl exec -n greenearth-stage "$POD" -- curl -sk -X DELETE -u "elastic:$ELASTIC_PASS" "https://greenearth-es-http:9200/replies-2026-06-19-${HOUR}"
done
```

## Prod

No manual cleanup needed — prod uses weekly rollover with 60d ILM delete age and both existing indices (replies-2026-w24, replies-2026-w25) are < 14 days old.