### PR TITLE
Make index migration script interrupt-safe and resumable

### DIFF
--- a/tools/Pipfile
+++ b/tools/Pipfile
@@ -9,6 +9,8 @@ aiohttp = "*"
 rich = "*"
 
 [dev-packages]
+pytest = "*"
+pytest-asyncio = "*"
 
 [requires]
 python_version = "3.13"

--- a/tools/Pipfile.lock
+++ b/tools/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4a3c7382a1b684b97131e1f64fe1b0eebf046cfee149398f1131bf9938b2cae1"
+            "sha256": "e122feeea61c8035cd3637aa4338c8681a50aef292226ce3640e46c914fa66c2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -806,5 +806,56 @@
             "version": "==1.24.2"
         }
     },
-    "develop": {}
+    "develop": {
+        "iniconfig": {
+            "hashes": [
+                "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730",
+                "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.3.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==26.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+                "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.20.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313",
+                "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==9.1.1"
+        },
+        "pytest-asyncio": {
+            "hashes": [
+                "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1",
+                "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==1.4.0"
+        }
+    }
 }

--- a/tools/pytest.ini
+++ b/tools/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tools/reindex.py
+++ b/tools/reindex.py
@@ -238,6 +238,49 @@ async def _index_exists(es: AsyncElasticsearch, index: str) -> bool:
         return False
 
 
+async def _doc_count(es: AsyncElasticsearch, index: str) -> int | None:
+    """Return the document count for index, or None if it does not exist."""
+    try:
+        resp = await es.count(index=index)
+        return int(resp["count"])
+    except NotFoundError:
+        return None
+
+
+async def _task_running(es: AsyncElasticsearch, task_id: str) -> bool:
+    """Return True if the task exists and has not yet completed."""
+    try:
+        task = await es.tasks.get(task_id=task_id)
+        return task.get("completed") is not True
+    except NotFoundError:
+        return False
+
+
+async def _find_running_reindex_to(es: AsyncElasticsearch, dst: str) -> str | None:
+    """Return the id of a running reindex task writing into dst, if any.
+
+    Adopting an orphaned reindex (e.g. one whose driving script was Ctrl-C'd)
+    lets us re-attach to it instead of starting a competing reindex into the
+    same destination — which would collide on op_type=create version conflicts.
+    """
+    try:
+        resp = await es.tasks.list(
+            actions="indices:data/write/reindex", detailed=True,
+        )
+    except Exception:
+        return None
+
+    suffix = f"to [{dst}]"
+    for node in (resp.get("nodes") or {}).values():
+        for task_id, task in (node.get("tasks") or {}).items():
+            desc = task.get("description") or ""
+            # Only the parent reindex task carries the "from [..] to [..]"
+            # description; sliced child tasks are just "reindex" and are skipped.
+            if desc.startswith("reindex from") and desc.endswith(suffix):
+                return task_id
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Migration steps
 # ---------------------------------------------------------------------------
@@ -252,7 +295,12 @@ async def _poll_task(
     Returns the final task status: SWAP_PENDING on success, FAILED on failure.
     """
     task_id = state.indices[src].task_id
+    dst = state.indices[src].dst
     _info(f"  Polling task [cyan]{task_id}[/cyan] ...")
+
+    # Source is no longer receiving writes (active indices are skipped), so its
+    # count is a stable denominator for progress.
+    src_count = await _doc_count(es, src)
 
     while True:
         await asyncio.sleep(POLL_INTERVAL_SECS)
@@ -260,35 +308,35 @@ async def _poll_task(
         try:
             task = await es.tasks.get(task_id=task_id)
         except NotFoundError:
-            # Task completed and was evicted from the task store; treat as done.
-            _info(f"  Task {task_id} evicted from task store — checking destination index ...")
-            dst = state.indices[src].dst
-            if await _index_exists(es, dst):
-                _info(f"  Destination {dst} exists — proceeding to alias swap.")
+            # Task evicted from the task store. Only treat as done if the
+            # destination is actually complete — otherwise the reindex was
+            # interrupted and must be restarted.
+            _info(f"  Task {task_id} evicted from task store — checking destination count ...")
+            dst_count = await _doc_count(es, dst)
+            if dst_count is not None and src_count is not None and dst_count >= src_count:
+                _info(f"  Destination {dst} complete ({dst_count:,}/{src_count:,}) — proceeding to alias swap.")
                 return SWAP_PENDING
-            else:
-                _warn(f"  Destination {dst} not found after task eviction — will restart reindex.")
-                return FAILED
+            _warn(f"  Destination {dst} incomplete after eviction ({dst_count}/{src_count}) — will restart reindex.")
+            return FAILED
 
         completed: bool = task.get("completed") is True
-        status = (task.get("task") or {}).get("status") or {}
-        total     = int(status.get("total", 0))
-        created   = int(status.get("created", 0))
-        conflicts = int(status.get("version_conflicts", 0))
-        processed = created + conflicts
 
-        if total > 0:
-            pct = processed * 100 / total
-            _info(f"  {src}: {processed:,} / {total:,} docs ({pct:.1f}%)")
+        # Report progress from document counts. The sliced-reindex parent task
+        # reports total=0 with null slices until every slice finishes its first
+        # scroll, so the task status is unreliable for progress.
+        dst_count = await _doc_count(es, dst)
+        if src_count and dst_count is not None:
+            pct = dst_count * 100 / src_count
+            _info(f"  {src}: {dst_count:,} / {src_count:,} docs ({pct:.1f}%)")
         else:
-            _info(f"  {src}: task running, waiting for doc count...")
+            _info(f"  {src}: reindexing (dst={dst_count}, src={src_count}) ...")
 
         if not completed:
             continue
 
         result = task.get("response") or {}
-        final_created   = result.get("created", created)
-        final_conflicts = result.get("version_conflicts", conflicts)
+        final_created   = result.get("created", 0)
+        final_conflicts = result.get("version_conflicts", 0)
         final_failures  = result.get("failures") or []
         took_ms         = result.get("took", 0)
 
@@ -369,6 +417,58 @@ async def _do_swap(
     return DONE
 
 
+async def _ensure_reindex(
+    es: AsyncElasticsearch,
+    state: RunState,
+    src: str,
+) -> str:
+    """Decide how to (re)start work for src and return the next status.
+
+    Returns REINDEXING (a task is running — poll it), SWAP_PENDING (destination
+    already complete), DONE (destination already live behind an alias), or
+    FAILED (could not start a fresh reindex).
+    """
+    idx = state.indices[src]
+    dst = idx.dst
+
+    # 1. A reindex we already know about is still running — re-attach to it.
+    if idx.task_id and await _task_running(es, idx.task_id):
+        _info(f"  Reattaching to running task [cyan]{idx.task_id}[/cyan]")
+        return REINDEXING
+
+    # 2. An untracked reindex is already writing to dst (e.g. orphaned by an
+    #    earlier Ctrl-C) — adopt it rather than competing with it.
+    orphan = await _find_running_reindex_to(es, dst)
+    if orphan:
+        _info(f"  Adopting running reindex into {dst}: [cyan]{orphan}[/cyan]")
+        state.update(src, task_id=orphan, status=REINDEXING)
+        return REINDEXING
+
+    # 3. No reindex running — inspect the destination.
+    if await _index_exists(es, dst):
+        dst_aliases = await _get_aliases(es, dst)
+        if dst_aliases:
+            # Destination already serves an alias — never delete a live index.
+            _info(f"  Destination {dst} already live (aliases: {', '.join(dst_aliases)}).")
+            return DONE
+
+        src_count = await _doc_count(es, src)
+        dst_count = await _doc_count(es, dst)
+        if dst_count is not None and src_count is not None and dst_count >= src_count:
+            _info(f"  Destination {dst} already complete ({dst_count:,}/{src_count:,}) — skipping reindex.")
+            return SWAP_PENDING
+
+        # Alias-less, incomplete leftover — safe to delete and restart fresh.
+        _warn(f"  Removing partial destination {dst} ({dst_count}/{src_count}) and restarting.")
+        try:
+            await es.indices.delete(index=dst)
+        except NotFoundError:
+            pass
+
+    # 4. Start a fresh reindex.
+    return await _start_reindex(es, state, src)
+
+
 async def _process_index(
     es: AsyncElasticsearch,
     state: RunState | None,
@@ -391,11 +491,17 @@ async def _process_index(
     _info(f"Migrating [bold]{src}[/bold] → [bold]{idx.dst}[/bold]"
           + (f" [dim](resuming from {idx.status})[/dim]" if idx.status != PENDING else ""))
 
-    # ── Step 1: ensure reindex is running ───────────────────────────────────
-    if idx.status in (PENDING, FAILED):
-        new_status = await _start_reindex(es, state, src)
+    # ── Step 1: ensure a reindex is running, complete, or already live ──────
+    if idx.status in (PENDING, FAILED, REINDEXING):
+        new_status = await _ensure_reindex(es, state, src)
         if new_status == FAILED:
             state.update(src, status=FAILED, error="Failed to start reindex")
+            return
+        # Clear any stale error from a previous failed attempt.
+        state.update(src, status=new_status, error=None)
+        if new_status == DONE:
+            state.update(src, completed_at=_now())
+            _info(f"  [green]✓[/green] {src} → {idx.dst} (already migrated)")
             return
 
     # ── Step 2: poll until reindex finishes ─────────────────────────────────
@@ -646,7 +752,17 @@ examples:
         help="Discard any saved state and start the migration from scratch.",
     )
     args = parser.parse_args()
-    sys.exit(asyncio.run(_run(args)))
+    try:
+        exit_code = asyncio.run(_run(args))
+    except KeyboardInterrupt:
+        console.print()
+        _warn(
+            "Interrupted — any in-flight Elasticsearch reindex task keeps running "
+            "server-side. Re-run with the same --types to resume; the script will "
+            "re-attach to the running task."
+        )
+        sys.exit(130)
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/tools/test_reindex.py
+++ b/tools/test_reindex.py
@@ -1,0 +1,266 @@
+"""Unit tests for the resilience logic in reindex.py.
+
+These cover the interrupt-safe resume path: re-attaching to running reindex
+tasks, adopting orphaned reindexes, count-based progress, and the safety guard
+that prevents deleting a destination that is already serving an alias.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from elasticsearch import NotFoundError
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import reindex  # noqa: E402
+from reindex import (  # noqa: E402
+    DONE,
+    FAILED,
+    PENDING,
+    REINDEXING,
+    SWAP_PENDING,
+    IndexState,
+    RunState,
+)
+
+
+def _nf() -> NotFoundError:
+    return NotFoundError("not found", meta=None, body=None)
+
+
+def _es() -> AsyncMock:
+    return AsyncMock()
+
+
+def _state(src: str, dst: str, status: str = PENDING, task_id=None) -> RunState:
+    st = RunState.create("abc1234", ["posts"])
+    st.indices[src] = IndexState(status=status, src=src, dst=dst, task_id=task_id)
+    st.save = lambda: None  # never touch disk in tests
+    return st
+
+
+# ---------------------------------------------------------------------------
+# _doc_count
+# ---------------------------------------------------------------------------
+
+async def test_doc_count_returns_count():
+    es = _es()
+    es.count.return_value = {"count": 42}
+    assert await reindex._doc_count(es, "x") == 42
+
+
+async def test_doc_count_missing_returns_none():
+    es = _es()
+    es.count.side_effect = _nf()
+    assert await reindex._doc_count(es, "x") is None
+
+
+# ---------------------------------------------------------------------------
+# _task_running
+# ---------------------------------------------------------------------------
+
+async def test_task_running_true_when_not_completed():
+    es = _es()
+    es.tasks.get.return_value = {"completed": False}
+    assert await reindex._task_running(es, "t1") is True
+
+
+async def test_task_running_false_when_completed():
+    es = _es()
+    es.tasks.get.return_value = {"completed": True}
+    assert await reindex._task_running(es, "t1") is False
+
+
+async def test_task_running_false_when_evicted():
+    es = _es()
+    es.tasks.get.side_effect = _nf()
+    assert await reindex._task_running(es, "t1") is False
+
+
+# ---------------------------------------------------------------------------
+# _find_running_reindex_to
+# ---------------------------------------------------------------------------
+
+async def test_find_running_reindex_to_matches_description():
+    es = _es()
+    es.tasks.list.return_value = {
+        "nodes": {
+            "node1": {
+                "tasks": {
+                    "node1:111": {
+                        "description": "reindex from [posts-2026-w25] to [posts-2026-w25-abc1234]",
+                    },
+                    "node1:112": {  # a slice child — must be ignored
+                        "description": "reindex",
+                    },
+                }
+            }
+        }
+    }
+    found = await reindex._find_running_reindex_to(es, "posts-2026-w25-abc1234")
+    assert found == "node1:111"
+
+
+async def test_find_running_reindex_to_no_match():
+    es = _es()
+    es.tasks.list.return_value = {
+        "nodes": {
+            "node1": {
+                "tasks": {
+                    "node1:111": {
+                        "description": "reindex from [other] to [other-abc1234]",
+                    }
+                }
+            }
+        }
+    }
+    assert await reindex._find_running_reindex_to(es, "posts-2026-w25-abc1234") is None
+
+
+# ---------------------------------------------------------------------------
+# _ensure_reindex
+# ---------------------------------------------------------------------------
+
+async def test_ensure_reindex_reattaches_running_stored_task(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=FAILED, task_id="t1")
+    monkeypatch.setattr(reindex, "_task_running", AsyncMock(return_value=True))
+    start = AsyncMock()
+    monkeypatch.setattr(reindex, "_start_reindex", start)
+
+    assert await reindex._ensure_reindex(es, st, "s") == REINDEXING
+    start.assert_not_awaited()
+
+
+async def test_ensure_reindex_adopts_orphan(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=FAILED, task_id="dead")
+    monkeypatch.setattr(reindex, "_task_running", AsyncMock(return_value=False))
+    monkeypatch.setattr(reindex, "_find_running_reindex_to", AsyncMock(return_value="orphan99"))
+    start = AsyncMock()
+    monkeypatch.setattr(reindex, "_start_reindex", start)
+
+    assert await reindex._ensure_reindex(es, st, "s") == REINDEXING
+    assert st.indices["s"].task_id == "orphan99"
+    start.assert_not_awaited()
+
+
+async def test_ensure_reindex_dst_aliased_returns_done_without_delete(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=FAILED)
+    monkeypatch.setattr(reindex, "_task_running", AsyncMock(return_value=False))
+    monkeypatch.setattr(reindex, "_find_running_reindex_to", AsyncMock(return_value=None))
+    monkeypatch.setattr(reindex, "_index_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(reindex, "_get_aliases", AsyncMock(return_value={"posts": {}}))
+    start = AsyncMock()
+    monkeypatch.setattr(reindex, "_start_reindex", start)
+
+    assert await reindex._ensure_reindex(es, st, "s") == DONE
+    es.indices.delete.assert_not_awaited()
+    start.assert_not_awaited()
+
+
+async def test_ensure_reindex_complete_dst_skips_to_swap(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=FAILED)
+    monkeypatch.setattr(reindex, "_task_running", AsyncMock(return_value=False))
+    monkeypatch.setattr(reindex, "_find_running_reindex_to", AsyncMock(return_value=None))
+    monkeypatch.setattr(reindex, "_index_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(reindex, "_get_aliases", AsyncMock(return_value={}))
+    monkeypatch.setattr(reindex, "_doc_count", AsyncMock(side_effect=[100, 100]))  # src, dst
+    start = AsyncMock()
+    monkeypatch.setattr(reindex, "_start_reindex", start)
+
+    assert await reindex._ensure_reindex(es, st, "s") == SWAP_PENDING
+    es.indices.delete.assert_not_awaited()
+    start.assert_not_awaited()
+
+
+async def test_ensure_reindex_partial_dst_deletes_and_restarts(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=FAILED)
+    monkeypatch.setattr(reindex, "_task_running", AsyncMock(return_value=False))
+    monkeypatch.setattr(reindex, "_find_running_reindex_to", AsyncMock(return_value=None))
+    monkeypatch.setattr(reindex, "_index_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(reindex, "_get_aliases", AsyncMock(return_value={}))
+    monkeypatch.setattr(reindex, "_doc_count", AsyncMock(side_effect=[100, 30]))  # src, dst partial
+    start = AsyncMock(return_value=REINDEXING)
+    monkeypatch.setattr(reindex, "_start_reindex", start)
+
+    assert await reindex._ensure_reindex(es, st, "s") == REINDEXING
+    es.indices.delete.assert_awaited_once()
+    start.assert_awaited_once()
+
+
+async def test_ensure_reindex_missing_dst_starts_fresh(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=PENDING)
+    monkeypatch.setattr(reindex, "_task_running", AsyncMock(return_value=False))
+    monkeypatch.setattr(reindex, "_find_running_reindex_to", AsyncMock(return_value=None))
+    monkeypatch.setattr(reindex, "_index_exists", AsyncMock(return_value=False))
+    start = AsyncMock(return_value=REINDEXING)
+    monkeypatch.setattr(reindex, "_start_reindex", start)
+
+    assert await reindex._ensure_reindex(es, st, "s") == REINDEXING
+    es.indices.delete.assert_not_awaited()
+    start.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _poll_task
+# ---------------------------------------------------------------------------
+
+async def test_poll_task_reports_counts_and_completes(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=REINDEXING, task_id="t1")
+    monkeypatch.setattr(reindex.asyncio, "sleep", AsyncMock())
+    # src count (pre-loop), then dst counts per iteration
+    monkeypatch.setattr(reindex, "_doc_count", AsyncMock(side_effect=[100, 50, 100]))
+    es.tasks.get.side_effect = [
+        {"completed": False, "task": {"status": {}}},
+        {
+            "completed": True,
+            "task": {"status": {}},
+            "response": {"created": 100, "version_conflicts": 0, "failures": [], "took": 5},
+        },
+    ]
+
+    assert await reindex._poll_task(es, st, "s") == SWAP_PENDING
+
+
+async def test_poll_task_failures_return_failed(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=REINDEXING, task_id="t1")
+    monkeypatch.setattr(reindex.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(reindex, "_doc_count", AsyncMock(side_effect=[100, 100]))
+    es.tasks.get.side_effect = [
+        {
+            "completed": True,
+            "task": {"status": {}},
+            "response": {"created": 0, "version_conflicts": 5, "failures": [{"x": 1}], "took": 2},
+        },
+    ]
+
+    assert await reindex._poll_task(es, st, "s") == FAILED
+
+
+async def test_poll_task_eviction_complete_returns_swap(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=REINDEXING, task_id="t1")
+    monkeypatch.setattr(reindex.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(reindex, "_doc_count", AsyncMock(side_effect=[100, 100]))  # src, dst on eviction
+    es.tasks.get.side_effect = _nf()
+
+    assert await reindex._poll_task(es, st, "s") == SWAP_PENDING
+
+
+async def test_poll_task_eviction_partial_returns_failed(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=REINDEXING, task_id="t1")
+    monkeypatch.setattr(reindex.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(reindex, "_doc_count", AsyncMock(side_effect=[100, 30]))  # src, dst on eviction
+    es.tasks.get.side_effect = _nf()
+
+    assert await reindex._poll_task(es, st, "s") == FAILED


### PR DESCRIPTION
Follow-up to #388 (mappings/`PostDoc`/`ReplyDoc` split + `tools/reindex.py`, merged in #389).

A live prod migration run got wedged: killing the script does not cancel the server-side Elasticsearch reindex task, so on restart the script saw the index as `failed`, started a *second* `op_type: create` reindex into the same destination while the original was still filling it, and every doc came back as a `version_conflict` → re-marked `failed` → looped forever. Progress also appeared hung because the sliced-reindex parent task reports `total: 0` (all slices `null`) until every slice finishes its first scroll.

# This PR

Makes `tools/reindex.py` interrupt-safe and resumable:

- **Adopt orphaned reindexes** — new `_find_running_reindex_to(dst)` discovers a running reindex writing to the destination (by task description) and re-attaches to it instead of starting a competing one. New `_ensure_reindex()` centralizes the resume decision: re-poll a tracked running task → adopt an untracked orphan → skip to swap if the destination is already complete → else start fresh.
- **Safe partial-destination cleanup** — on retry, a leftover destination is deleted and reindexed fresh **only if it is alias-less** (not swapped/live). A destination already serving an alias is treated as already-migrated and never deleted.
- **Count-based progress** — `_poll_task` reports `dst_count / src_count (%)` from `_count` instead of the unreliable task-status `total`. Task-store eviction now only advances to the alias swap when `dst_count >= src_count`; an incomplete destination restarts the reindex.
- **SIGINT leaves the task running** — Ctrl-C exits gracefully (code 130) without cancelling the ES task; state stays `reindexing` and the next run re-attaches.

# Testing

- `cd tools && pipenv install --dev && pipenv run pytest -v` — 17 unit tests pass (AsyncMock ES), covering `_ensure_reindex` (re-attach / adopt-orphan / aliased-dst→done-no-delete / complete-dst→swap / partial-dst→delete+restart / missing-dst→fresh), `_poll_task` count progress + completion + eviction (complete vs partial), and the `_doc_count` / `_task_running` / `_find_running_reindex_to` helpers.
- Verified module import and `--help` parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)