### PR TITLE
Reduce posts/replies shard count to 3; add ILM warm forcemerge phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ For detailed architecture information, see [VPC_ARCHITECTURE.md](VPC_ARCHITECTUR
 
 ## Index Schema Migrations
 
-When the Elasticsearch index mappings change (e.g. adding or removing fields, changing `index` flags, or dropping HNSW graphs), existing indices must be reindexed — ILM templates only apply to newly created indices.
+When the Elasticsearch index mappings change (e.g. adding or removing fields, changing `index` flags, changing shard counts, or dropping HNSW graphs), existing indices must be reindexed — ILM templates only apply to newly created indices.
 
-Use `tools/reindex.py` to migrate live indices. The script reindexes each source index into a new destination named `<index>-<commit>`, atomically swaps all aliases, and deletes the source.
+Use `tools/reindex.py` to migrate live indices. The script reindexes each source index into a new destination named `<index>-<commit>`, atomically swaps all aliases, and deletes the source. It supports two independent operations that can be run separately or together:
+
+- **`--migrate`** — reindex + alias swap
+- **`--force-merge`** — reduce each index to 1 Lucene segment (reduces per-shard term-seek cost ~30×; heavy I/O, run off-peak)
 
 ### Setup
 
@@ -60,7 +63,7 @@ Before running a migration:
 1. Deploy the updated ILM index templates (runs automatically via the deploy script's bootstrap job, or manually with `kubectl apply`).
 2. Deploy the new ingest service version so new documents are written in the updated format.
 
-### Running a migration
+### Credentials
 
 Export ES credentials (or set them in your shell environment):
 
@@ -73,37 +76,62 @@ export GE_ELASTICSEARCH_TLS_SKIP_VERIFY=true      # stage only (self-signed cert
 
 The `elastic` superuser has full cluster privileges and can read all aliases, which is required for the active-index safety check.
 
-Dry-run first to preview what will happen:
+### Migration workflow
+
+The active write index is skipped by default. The typical workflow for a full migration is two passes:
+
+**Pass 1 — migrate all historical indices** (the active write index is skipped automatically):
 
 ```bash
 cd tools
-pipenv run python reindex.py --types posts replies --dry-run
+pipenv run python reindex.py --migrate --types posts replies --dry-run  # preview
+pipenv run python reindex.py --migrate --types posts replies
 ```
 
-Run the migration (the active write index is skipped by default):
+**Pass 2 — after the period rolls over**, the formerly-active index is now historical. Target it by name with `--indices` to complete the migration:
 
 ```bash
-pipenv run python reindex.py --types posts replies
+# Identify the formerly-active index (e.g. posts-2026-w26)
+pipenv run python reindex.py --migrate --indices posts-2026-w26 replies-2026-w26
 ```
 
-**After a period rollover:** the formerly-active index is no longer receiving writes and is included automatically in a normal run — no flags needed. The same command above handles it.
+`--indices` bypasses the active-index guard entirely, so no confirmation prompt is needed. This is the safe and recommended way to handle the formerly-active index after rollover.
 
-**`--include-active` should only be used when you specifically need to migrate the index that is currently receiving live writes** (e.g. in a dev environment or a maintenance window). It carries a data loss risk: documents written to the source after reindex starts but before the alias swap completes are permanently lost when the source is deleted.
+### Force-merge
 
-Migrate all supported types at once:
+Force-merging reduces each shard's Lucene segments to 1, which cuts per-shard term-seek overhead ~30× and improves query latency on historical (read-only) indices. Run it off-peak — it is I/O-intensive.
 
 ```bash
-pipenv run python reindex.py --types posts replies likes
+# Standalone: submit all force-merges async, then poll with progress
+pipenv run python reindex.py --force-merge --types posts replies
+
+# Target specific indices by name
+pipenv run python reindex.py --force-merge --indices posts-2026-w25-abc1234
+```
+
+Combined with `--migrate`, force-merge fires automatically after each alias swap (fire-and-forget — not waited on, runs concurrently with the next index migration):
+
+```bash
+pipenv run python reindex.py --migrate --force-merge --types posts replies
+```
+
+### `--include-active` (last resort)
+
+`--include-active` reindexes the index currently receiving live writes. **Only use this when all ingest services have been stopped** — documents written after reindexing starts but before the alias swap completes are permanently lost. Prefer the two-pass workflow with `--indices` after rollover instead.
+
+```bash
+# Prompts for explicit confirmation before proceeding
+pipenv run python reindex.py --migrate --types posts replies --include-active
 ```
 
 ### Resuming after interruption
 
-State is written to `tools/state/reindex-state.json` after every step. If the script is interrupted or fails, re-run with the same `--types` flags and the same git commit in the working tree — it will skip completed indices and resume from where it left off.
+State is written to `tools/state/reindex-state.json` after every step. If the script is interrupted or fails, re-run with the same flags and the same git commit in the working tree — it will skip completed indices and resume from where it left off. In-flight Elasticsearch reindex tasks continue running server-side and are re-attached automatically on resume.
 
 To discard saved state and start the migration from scratch:
 
 ```bash
-pipenv run python reindex.py --types posts replies --reset
+pipenv run python reindex.py --migrate --types posts replies --reset
 ```
 
 ### Adding new index types
@@ -115,7 +143,7 @@ INDEX_TYPES = {
     ...
     "likes": {
         "pattern": "likes-*",
-        "active_alias": "likes_recent",
+        "active_alias": "likes",
     },
 }
 ```

--- a/index/deploy/k8s/base/bootstrap-job.yaml
+++ b/index/deploy/k8s/base/bootstrap-job.yaml
@@ -25,6 +25,11 @@ spec:
             configMapKeyRef:
               name: ilm-settings
               key: ilm_delete_age
+        - name: ILM_FORCEMERGE_AGE
+          valueFrom:
+            configMapKeyRef:
+              name: ilm-settings
+              key: ilm_forcemerge_age
         command:
         - /bin/sh
         - -c
@@ -46,16 +51,17 @@ spec:
             -d "{\"policy\":{\"phases\":{\"hot\":{\"min_age\":\"0ms\",\"actions\":{\"rollover\":{\"max_age\":\"$INFERENCE_MAX_AGE\"}}},\"delete\":{\"min_age\":\"0ms\",\"actions\":{\"delete\":{}}}}}}"
 
           ILM_DELETE_POLICY="{\"policy\":{\"phases\":{\"delete\":{\"min_age\":\"$ILM_DELETE_AGE\",\"actions\":{\"delete\":{}}}}}}"
+          ILM_FORCEMERGE_POLICY="{\"policy\":{\"phases\":{\"warm\":{\"min_age\":\"$ILM_FORCEMERGE_AGE\",\"actions\":{\"forcemerge\":{\"max_num_segments\":1}}},\"delete\":{\"min_age\":\"$ILM_DELETE_AGE\",\"actions\":{\"delete\":{}}}}}}"
 
           curl -k --fail-with-body -X PUT "https://greenearth-es-http:9200/_ilm/policy/posts_ilm_policy" \
             -u "es-service-user:$ES_SERVICE_PASSWORD" \
             -H "Content-Type: application/json" \
-            -d "$ILM_DELETE_POLICY"
+            -d "$ILM_FORCEMERGE_POLICY"
 
           curl -k --fail-with-body -X PUT "https://greenearth-es-http:9200/_ilm/policy/replies_ilm_policy" \
             -u "es-service-user:$ES_SERVICE_PASSWORD" \
             -H "Content-Type: application/json" \
-            -d "$ILM_DELETE_POLICY"
+            -d "$ILM_FORCEMERGE_POLICY"
 
           curl -k --fail-with-body -X PUT "https://greenearth-es-http:9200/_ilm/policy/likes_ilm_policy" \
             -u "es-service-user:$ES_SERVICE_PASSWORD" \

--- a/index/deploy/k8s/environments/local/kustomization.yaml
+++ b/index/deploy/k8s/environments/local/kustomization.yaml
@@ -38,4 +38,5 @@ configMapGenerator:
       - replies_index_shards=1
       - replies_index_replicas=0
       - ilm_delete_age=30m
+      - ilm_forcemerge_age=5m
       - index_period=10min

--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -122,13 +122,14 @@ configMapGenerator:
   - name: ilm-settings
     behavior: replace
     literals:
-      - posts_index_shards=7
+      - posts_index_shards=3
       - posts_index_replicas=1
       - likes_index_shards=7
       - likes_index_replicas=1
       - tombstones_index_shards=3
       - tombstones_index_replicas=1
-      - replies_index_shards=7
+      - replies_index_shards=3
       - replies_index_replicas=1
       - ilm_delete_age=60d
+      - ilm_forcemerge_age=8d
       - index_period=week

--- a/index/deploy/k8s/environments/stage/kustomization.yaml
+++ b/index/deploy/k8s/environments/stage/kustomization.yaml
@@ -125,4 +125,5 @@ configMapGenerator:
       - replies_index_shards=2
       - replies_index_replicas=1
       - ilm_delete_age=4h
+      - ilm_forcemerge_age=30m
       - index_period=hour

--- a/tools/reindex.py
+++ b/tools/reindex.py
@@ -19,9 +19,9 @@ the script will skip completed indices and pick up where it left off.
 
 Run from the tools/ directory:
     pipenv run python reindex.py --types posts replies --dry-run
-    pipenv run python reindex.py --types posts replies --include-active
-    pipenv run python reindex.py --types posts replies likes
     pipenv run python reindex.py --types posts replies --force-merge
+    pipenv run python reindex.py --indices posts-2026-w26 replies-2026-w26
+    pipenv run python reindex.py --types posts replies --include-active
 
 Prerequisites:
   - Updated ILM templates have been deployed (bootstrap job or manual PUT).
@@ -113,6 +113,7 @@ class RunState:
     types: list[str]
     created_at: str
     indices: dict[str, IndexState] = field(default_factory=dict)
+    explicit_indices: list[str] = field(default_factory=list)
 
     # ---- Persistence -------------------------------------------------------
 
@@ -121,6 +122,7 @@ class RunState:
         data = {
             "commit": self.commit,
             "types": self.types,
+            "explicit_indices": self.explicit_indices,
             "created_at": self.created_at,
             "indices": {
                 src: dataclasses.asdict(s)
@@ -144,6 +146,7 @@ class RunState:
             return cls(
                 commit=data["commit"],
                 types=data["types"],
+                explicit_indices=data.get("explicit_indices", []),
                 created_at=data["created_at"],
                 indices={
                     src: IndexState(**vals)
@@ -154,8 +157,18 @@ class RunState:
             return None
 
     @classmethod
-    def create(cls, commit: str, types: list[str]) -> RunState:
-        return cls(commit=commit, types=sorted(types), created_at=_now())
+    def create(
+        cls,
+        commit: str,
+        types: list[str],
+        explicit_indices: list[str] | None = None,
+    ) -> RunState:
+        return cls(
+            commit=commit,
+            types=sorted(types),
+            explicit_indices=sorted(explicit_indices or []),
+            created_at=_now(),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -173,6 +186,30 @@ def _warn(msg: str) -> None:
 def _die(msg: str) -> None:
     console.print(f"[red][ERROR][/red] {msg}")
     sys.exit(1)
+
+
+def _confirm_include_active(active_index: str, type_name: str) -> bool:
+    """Warn about data loss and prompt for confirmation before reindexing the active write index."""
+    console.print()
+    console.print(
+        f"[bold red][WARNING][/bold red]  --include-active will reindex [bold]{active_index}[/bold] "
+        f"(active write index for '{type_name}')."
+    )
+    console.print()
+    console.print(
+        "  [yellow]Data-loss risk:[/yellow] While reindexing, the write alias continues pointing to the\n"
+        "  source index. Documents written after reindexing starts will NOT be present in\n"
+        "  the destination and will be [bold]permanently lost[/bold] when the alias is swapped."
+    )
+    console.print()
+    console.print("  [bold]Only proceed when all ingest services have been stopped.[/bold]")
+    console.print()
+    try:
+        answer = input("  Proceed with reindexing the active index? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        console.print()
+        return False
+    return answer == "y"
 
 
 # ---------------------------------------------------------------------------
@@ -592,7 +629,8 @@ async def _run(args: argparse.Namespace) -> int:
         console.print()
 
         # ── State init ───────────────────────────────────────────────────────
-        sorted_types = sorted(args.types)
+        sorted_types = sorted(args.types or [])
+        sorted_explicit = sorted(args.indices or [])
         state: RunState | None = None
 
         if not args.dry_run:
@@ -602,7 +640,20 @@ async def _run(args: argparse.Namespace) -> int:
             else:
                 state = RunState.load()
                 if state is not None:
-                    if state.commit == commit and sorted(state.types) == sorted_types:
+                    if sorted_explicit:
+                        state_matches = (
+                            state.commit == commit
+                            and sorted(state.explicit_indices) == sorted_explicit
+                        )
+                        state_desc = f"commit={state.commit}, indices={state.explicit_indices}"
+                    else:
+                        state_matches = (
+                            state.commit == commit
+                            and sorted(state.types) == sorted_types
+                        )
+                        state_desc = f"commit={state.commit}, types={state.types}"
+
+                    if state_matches:
                         done = sum(1 for s in state.indices.values() if s.status == DONE)
                         total_tracked = len(state.indices)
                         _info(
@@ -611,56 +662,27 @@ async def _run(args: argparse.Namespace) -> int:
                         )
                     else:
                         _warn(
-                            f"State file is for a different run "
-                            f"(commit={state.commit}, types={state.types}). "
+                            f"State file is for a different run ({state_desc}). "
                             f"Use --reset to start fresh."
                         )
                         return 1
 
             if state is None:
-                state = RunState.create(commit, sorted_types)
+                state = RunState.create(commit, sorted_types, explicit_indices=sorted_explicit or None)
                 state.save()
                 _info(f"State file: {STATE_FILE}")
 
             console.print()
 
-        # ── Discover indices ─────────────────────────────────────────────────
+        # ── Discover and process indices ─────────────────────────────────────
         errors = 0
 
-        for type_name in sorted_types:
-            cfg = INDEX_TYPES[type_name]
-            pattern = cfg["pattern"]
-            active_alias = cfg["active_alias"]
+        if sorted_explicit:
+            # ── Explicit-index mode: process only the named indices ──────────
+            _info(f"=== Explicit indices (active-index guard bypassed) ===")
 
-            active_index: str | None = None
-            if not args.include_active:
-                active_index = await _active_index_for(es, active_alias)
-                if active_index:
-                    _warn(f"Skipping active {type_name} index: {active_index}")
-                    console.print(
-                        "  (Re-run with --include-active after the period rolls over.)"
-                    )
-                    console.print()
-
-            _info(f"=== {pattern} (newest first) ===")
-            indices = await _list_indices(es, pattern)
-
-            if not indices:
-                _info(f"No indices found matching {pattern}")
-                console.print()
-                continue
-
-            for idx in indices:
-                # Register indices in state on first encounter (non-dry-run).
+            for idx in sorted_explicit:
                 if state is not None and idx not in state.indices:
-                    if idx == active_index:
-                        state.indices[idx] = IndexState(
-                            status=SKIPPED, src=idx, dst=f"{idx}-{commit}",
-                            error="active write index",
-                        )
-                        state.save()
-                        _warn(f"Skipping active index: {idx}")
-                        continue
                     if _MIGRATED_RE.search(idx):
                         state.indices[idx] = IndexState(
                             status=SKIPPED, src=idx, dst=idx,
@@ -674,10 +696,6 @@ async def _run(args: argparse.Namespace) -> int:
                     )
                     state.save()
                 else:
-                    # Dry-run or already in state: apply simple guards.
-                    if idx == active_index:
-                        _warn(f"Skipping active index: {idx}")
-                        continue
                     if _MIGRATED_RE.search(idx) and (state is None or idx not in state.indices):
                         _info(f"Skipping already-migrated index: {idx}")
                         continue
@@ -693,6 +711,82 @@ async def _run(args: argparse.Namespace) -> int:
                     errors += 1
 
             console.print()
+
+        else:
+            # ── Type-discovery mode: pattern-scan per type ───────────────────
+            for type_name in sorted_types:
+                cfg = INDEX_TYPES[type_name]
+                pattern = cfg["pattern"]
+                active_alias = cfg["active_alias"]
+
+                active_index: str | None = None
+                if args.include_active:
+                    active_index = await _active_index_for(es, active_alias)
+                    if active_index and not _confirm_include_active(active_index, type_name):
+                        _warn(f"Skipping {type_name} — confirmation declined.")
+                        console.print()
+                        active_index = None  # treat as if --include-active not set for this type
+                        # fall through: pattern discovery will still skip it via active_index guard below
+                else:
+                    active_index = await _active_index_for(es, active_alias)
+                    if active_index:
+                        _warn(f"Skipping active {type_name} index: {active_index}")
+                        console.print(
+                            "  (Use --indices to target it by name after the period rolls over.)"
+                        )
+                        console.print()
+
+                _info(f"=== {pattern} (newest first) ===")
+                indices = await _list_indices(es, pattern)
+
+                if not indices:
+                    _info(f"No indices found matching {pattern}")
+                    console.print()
+                    continue
+
+                for idx in indices:
+                    # Register indices in state on first encounter (non-dry-run).
+                    if state is not None and idx not in state.indices:
+                        if idx == active_index:
+                            state.indices[idx] = IndexState(
+                                status=SKIPPED, src=idx, dst=f"{idx}-{commit}",
+                                error="active write index",
+                            )
+                            state.save()
+                            _warn(f"Skipping active index: {idx}")
+                            continue
+                        if _MIGRATED_RE.search(idx):
+                            state.indices[idx] = IndexState(
+                                status=SKIPPED, src=idx, dst=idx,
+                                error="already migrated",
+                            )
+                            state.save()
+                            _info(f"Skipping already-migrated index: {idx}")
+                            continue
+                        state.indices[idx] = IndexState(
+                            status=PENDING, src=idx, dst=f"{idx}-{commit}",
+                        )
+                        state.save()
+                    else:
+                        # Dry-run or already in state: apply simple guards.
+                        if idx == active_index:
+                            _warn(f"Skipping active index: {idx}")
+                            continue
+                        if _MIGRATED_RE.search(idx) and (state is None or idx not in state.indices):
+                            _info(f"Skipping already-migrated index: {idx}")
+                            continue
+
+                    try:
+                        await _process_index(es, state, idx, commit, dry_run=args.dry_run, force_merge=args.force_merge)
+                        if state is not None and state.indices[idx].status == FAILED:
+                            errors += 1
+                    except Exception as exc:
+                        console.print(f"[red][ERROR][/red] {idx}: {exc}")
+                        if state is not None:
+                            state.update(idx, status=FAILED, error=str(exc))
+                        errors += 1
+
+                console.print()
 
         if errors:
             console.print(
@@ -727,22 +821,41 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 examples:
+  # Reindex all historical (non-active) posts and replies indices
   pipenv run python reindex.py --types posts replies --dry-run
-  pipenv run python reindex.py --types posts replies --include-active
-  pipenv run python reindex.py --types posts replies likes
   pipenv run python reindex.py --types posts replies --force-merge
+
+  # After rollover: reindex the formerly-active index by name (no confirmation prompt)
+  pipenv run python reindex.py --indices posts-2026-w26 replies-2026-w26
+
+  # Reindex the active write index (requires confirmation; stop ingest services first)
+  pipenv run python reindex.py --types posts replies --include-active
+
+  # Start fresh, discarding any saved resume state
   pipenv run python reindex.py --types posts --reset
 """,
     )
-    parser.add_argument(
+    index_group = parser.add_mutually_exclusive_group(required=True)
+    index_group.add_argument(
         "--types",
         nargs="+",
         choices=list(INDEX_TYPES),
-        required=True,
         metavar="TYPE",
         help=(
-            f"Index types to migrate (required). "
-            f"Choices: {', '.join(INDEX_TYPES)}."
+            f"Discover and migrate all indices of the given type(s). "
+            f"Choices: {', '.join(INDEX_TYPES)}. "
+            f"Mutually exclusive with --indices."
+        ),
+    )
+    index_group.add_argument(
+        "--indices",
+        nargs="+",
+        metavar="INDEX",
+        help=(
+            "Migrate specific named indices (e.g. posts-2026-w26) instead of "
+            "discovering by type. Bypasses the active-index guard, so you can "
+            "reindex a formerly-active index after the write period rolls over "
+            "without using --include-active. Mutually exclusive with --types."
         ),
     )
     parser.add_argument(
@@ -754,9 +867,9 @@ examples:
         "--include-active",
         action="store_true",
         help=(
-            "Also migrate the index currently receiving live writes "
-            "(the is_write_index member of the posts/replies/likes alias). "
-            "Only safe once the current write period has rolled over."
+            "Also migrate the index currently receiving live writes. "
+            "Prompts for confirmation before proceeding — only safe when all ingest "
+            "services are stopped. Prefer --indices after the write period rolls over."
         ),
     )
     parser.add_argument(

--- a/tools/reindex.py
+++ b/tools/reindex.py
@@ -7,15 +7,15 @@ index is copied into ``<name>-<commit>`` where ``<commit>`` is the short HEAD
 commit hash, all aliases are moved atomically, and the source index is deleted.
 
 The index currently pointed to by the write alias (``posts``, ``replies``, or
-``likes``) is still receiving live writes and is skipped by default. Re-run
-with --include-active after the period rolls over and the new period's index
-is live. After migration the ingest service continues writing without changes
+``likes``) is still receiving live writes and is skipped by default. After the
+period rolls over, use ``--indices`` to target the formerly-active index by
+name. After migration the ingest service continues writing without changes
 because the alias ``is_write_index`` flag is preserved during the swap.
 
 State is written to tools/state/reindex-state.json after every transition so
 the script can be cancelled and resumed. If a run is interrupted, simply
-re-run with the same --types flags and the same commit in the working tree;
-the script will skip completed indices and pick up where it left off.
+re-run with the same flags and the same commit in the working tree; the script
+will skip completed indices and pick up where it left off.
 
 Run from the tools/ directory:
     pipenv run python reindex.py --migrate --types posts replies --dry-run
@@ -39,32 +39,29 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import dataclasses
-import json
 import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
 
 from elasticsearch import AsyncElasticsearch, AuthorizationException, NotFoundError
 from rich.console import Console
 
+from reindex_state import (  # noqa: F401 — re-exported for tests
+    DONE,
+    FAILED,
+    IndexState,
+    PENDING,
+    REINDEXING,
+    RunState,
+    SKIPPED,
+    STATE_FILE,
+    SWAP_PENDING,
+    _now,
+)
+
 console = Console()
-
-STATE_DIR = Path(__file__).parent / "state"
-STATE_FILE = STATE_DIR / "reindex-state.json"
-
-# Per-index status values.
-PENDING      = "pending"
-REINDEXING   = "reindexing"
-SWAP_PENDING = "swap_pending"
-DONE         = "done"
-SKIPPED      = "skipped"
-FAILED       = "failed"
 
 # ---------------------------------------------------------------------------
 # Index type registry — add new types here as new data classes are introduced.
@@ -73,103 +70,20 @@ FAILED       = "failed"
 INDEX_TYPES: dict[str, dict[str, str]] = {
     "posts": {
         "pattern": "posts-*",
-        "active_alias": "posts",   # write alias used by megastream/jetstream ingest
+        "active_alias": "posts",    # write alias used by megastream/jetstream ingest
     },
     "replies": {
         "pattern": "replies-*",
-        "active_alias": "replies", # write alias used by megastream ingest
+        "active_alias": "replies",  # write alias used by megastream ingest
     },
     "likes": {
         "pattern": "likes-*",
-        "active_alias": "likes",   # write alias used by jetstream ingest
+        "active_alias": "likes",    # write alias used by jetstream ingest
     },
 }
 
 POLL_INTERVAL_SECS = 10
 _MIGRATED_RE = re.compile(r"-[0-9a-f]{7}$")
-
-
-# ---------------------------------------------------------------------------
-# State management
-# ---------------------------------------------------------------------------
-
-def _now() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-@dataclass
-class IndexState:
-    status: str    # PENDING | REINDEXING | SWAP_PENDING | DONE | SKIPPED | FAILED
-    src: str
-    dst: str
-    task_id: str | None = None
-    error: str | None = None
-    started_at: str | None = None
-    completed_at: str | None = None
-
-
-@dataclass
-class RunState:
-    commit: str
-    types: list[str]
-    created_at: str
-    indices: dict[str, IndexState] = field(default_factory=dict)
-    explicit_indices: list[str] = field(default_factory=list)
-
-    # ---- Persistence -------------------------------------------------------
-
-    def save(self) -> None:
-        STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        data = {
-            "commit": self.commit,
-            "types": self.types,
-            "explicit_indices": self.explicit_indices,
-            "created_at": self.created_at,
-            "indices": {
-                src: dataclasses.asdict(s)
-                for src, s in self.indices.items()
-            },
-        }
-        STATE_FILE.write_text(json.dumps(data, indent=2))
-
-    def update(self, src: str, **kwargs: Any) -> None:
-        """Update fields on an index state entry and persist to disk immediately."""
-        for k, v in kwargs.items():
-            setattr(self.indices[src], k, v)
-        self.save()
-
-    @classmethod
-    def load(cls) -> RunState | None:
-        if not STATE_FILE.exists():
-            return None
-        try:
-            data = json.loads(STATE_FILE.read_text())
-            return cls(
-                commit=data["commit"],
-                types=data["types"],
-                explicit_indices=data.get("explicit_indices", []),
-                created_at=data["created_at"],
-                indices={
-                    src: IndexState(**vals)
-                    for src, vals in data.get("indices", {}).items()
-                },
-            )
-        except Exception:
-            return None
-
-    @classmethod
-    def create(
-        cls,
-        commit: str,
-        types: list[str],
-        explicit_indices: list[str] | None = None,
-    ) -> RunState:
-        return cls(
-            commit=commit,
-            types=sorted(types),
-            explicit_indices=sorted(explicit_indices or []),
-            created_at=_now(),
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -321,8 +235,35 @@ async def _find_running_reindex_to(es: AsyncElasticsearch, dst: str) -> str | No
 
 
 # ---------------------------------------------------------------------------
-# Migration steps
+# Reindex state machine (per-index)
 # ---------------------------------------------------------------------------
+
+async def _start_reindex(
+    es: AsyncElasticsearch,
+    state: RunState,
+    src: str,
+) -> str:
+    """Kick off an async sliced reindex. Returns REINDEXING or FAILED."""
+    dst = state.indices[src].dst
+    _info(f"  Starting async reindex (slices=auto, 2000 req/s) ...")
+
+    try:
+        resp = await es.reindex(
+            source={"index": src},
+            dest={"index": dst, "op_type": "create"},
+            wait_for_completion=False,
+            slices="auto",
+            requests_per_second=2000,
+        )
+    except Exception as exc:
+        _warn(f"  Failed to start reindex: {exc}")
+        return FAILED
+
+    task_id: str = resp["task"]
+    _info(f"  Task: [cyan]{task_id}[/cyan]")
+    state.update(src, status=REINDEXING, task_id=task_id, started_at=_now())
+    return REINDEXING
+
 
 async def _poll_task(
     es: AsyncElasticsearch,
@@ -331,7 +272,7 @@ async def _poll_task(
 ) -> str:
     """Poll a running reindex task until it finishes.
 
-    Returns the final task status: SWAP_PENDING on success, FAILED on failure.
+    Returns SWAP_PENDING on success, FAILED on failure.
     """
     task_id = state.indices[src].task_id
     dst = state.indices[src].dst
@@ -393,32 +334,151 @@ async def _poll_task(
         return SWAP_PENDING
 
 
-async def _start_reindex(
+async def _ensure_reindex(
     es: AsyncElasticsearch,
     state: RunState,
     src: str,
 ) -> str:
-    """Kick off an async sliced reindex. Returns REINDEXING or FAILED."""
+    """Decide how to (re)start work for src and return the next status.
+
+    Returns REINDEXING (a task is running — poll it), SWAP_PENDING (destination
+    already complete), DONE (destination already live behind an alias), or
+    FAILED (could not start a fresh reindex).
+    """
+    idx = state.indices[src]
+    dst = idx.dst
+
+    # 1. A reindex we already know about is still running — re-attach to it.
+    if idx.task_id and await _task_running(es, idx.task_id):
+        _info(f"  Reattaching to running task [cyan]{idx.task_id}[/cyan]")
+        return REINDEXING
+
+    # 2. An untracked reindex is already writing to dst (e.g. orphaned by an
+    #    earlier Ctrl-C) — adopt it rather than competing with it.
+    orphan = await _find_running_reindex_to(es, dst)
+    if orphan:
+        _info(f"  Adopting running reindex into {dst}: [cyan]{orphan}[/cyan]")
+        state.update(src, task_id=orphan, status=REINDEXING)
+        return REINDEXING
+
+    # 3. No reindex running — inspect the destination.
+    if await _index_exists(es, dst):
+        dst_aliases = await _get_aliases(es, dst)
+        if dst_aliases:
+            # Destination already serves an alias — never delete a live index.
+            _info(f"  Destination {dst} already live (aliases: {', '.join(dst_aliases)}).")
+            return DONE
+
+        src_count = await _doc_count(es, src)
+        dst_count = await _doc_count(es, dst)
+        if dst_count is not None and src_count is not None and dst_count >= src_count:
+            _info(f"  Destination {dst} already complete ({dst_count:,}/{src_count:,}) — skipping reindex.")
+            return SWAP_PENDING
+
+        # Alias-less, incomplete leftover — safe to delete and restart fresh.
+        _warn(f"  Removing partial destination {dst} ({dst_count}/{src_count}) and restarting.")
+        try:
+            await es.indices.delete(index=dst)
+        except NotFoundError:
+            pass
+
+    # 4. Start a fresh reindex.
+    return await _start_reindex(es, state, src)
+
+
+async def _do_swap(
+    es: AsyncElasticsearch,
+    state: RunState,
+    src: str,
+) -> str:
+    """Atomically move aliases from src to dst, then delete src. Returns DONE or FAILED."""
     dst = state.indices[src].dst
-    _info(f"  Starting async reindex (slices=auto, 2000 req/s) ...")
+
+    aliases = await _get_aliases(es, src)
+    actions: list[dict[str, Any]] = []
+    for alias_name, alias_cfg in aliases.items():
+        add: dict[str, Any] = {"index": dst, "alias": alias_name}
+        if alias_cfg.get("is_write_index"):
+            add["is_write_index"] = True
+        actions.append({"remove": {"index": src, "alias": alias_name}})
+        actions.append({"add": add})
+
+    if actions:
+        _info(f"  Moving aliases: {', '.join(aliases)}")
+        try:
+            await es.indices.update_aliases(actions=actions)
+        except Exception as exc:
+            _warn(f"  Alias swap failed: {exc}")
+            return FAILED
 
     try:
-        resp = await es.reindex(
-            source={"index": src},
-            dest={"index": dst, "op_type": "create"},
-            wait_for_completion=False,
-            slices="auto",
-            requests_per_second=2000,
-        )
+        await es.indices.delete(index=src)
+    except NotFoundError:
+        pass  # Already deleted — idempotent.
     except Exception as exc:
-        _warn(f"  Failed to start reindex: {exc}")
+        _warn(f"  Delete of {src} failed: {exc}")
         return FAILED
 
-    task_id: str = resp["task"]
-    _info(f"  Task: [cyan]{task_id}[/cyan]")
-    state.update(src, status=REINDEXING, task_id=task_id, started_at=_now())
-    return REINDEXING
+    return DONE
 
+
+async def _process_index(
+    es: AsyncElasticsearch,
+    state: RunState | None,
+    src: str,
+    commit: str,
+    dry_run: bool,
+) -> None:
+    """Drive one index through its full migration state machine (reindex → swap)."""
+    if dry_run:
+        _info(f"[dim][dry-run][/dim] Would reindex {src} → {src}-{commit}, swap aliases, delete src.")
+        return
+
+    assert state is not None
+    idx = state.indices[src]
+
+    if idx.status in (DONE, SKIPPED):
+        _info(f"Skipping [{idx.status}]: {src}")
+        return
+
+    _info(f"Migrating [bold]{src}[/bold] → [bold]{idx.dst}[/bold]"
+          + (f" [dim](resuming from {idx.status})[/dim]" if idx.status != PENDING else ""))
+
+    # ── Step 1: ensure a reindex is running, complete, or already live ──────
+    if idx.status in (PENDING, FAILED, REINDEXING):
+        new_status = await _ensure_reindex(es, state, src)
+        if new_status == FAILED:
+            state.update(src, status=FAILED, error="Failed to start reindex")
+            return
+        # Clear any stale error from a previous failed attempt.
+        state.update(src, status=new_status, error=None)
+        if new_status == DONE:
+            state.update(src, completed_at=_now())
+            _info(f"  [green]✓[/green] {src} → {idx.dst} (already migrated)")
+            return
+
+    # ── Step 2: poll until reindex finishes ─────────────────────────────────
+    if state.indices[src].status == REINDEXING:
+        new_status = await _poll_task(es, state, src)
+        state.update(src, status=new_status)
+        if new_status == FAILED:
+            state.update(src, error="Reindex task failed or destination missing after eviction")
+            return
+
+    # ── Step 3: atomic alias swap + delete ──────────────────────────────────
+    if state.indices[src].status == SWAP_PENDING:
+        new_status = await _do_swap(es, state, src)
+        state.update(src, status=new_status, completed_at=_now() if new_status == DONE else None)
+        if new_status == FAILED:
+            state.update(src, error="Alias swap or source deletion failed")
+            return
+
+    _info(f"  [green]✓[/green] {src} → {idx.dst}")
+
+
+# ---------------------------------------------------------------------------
+# Force-merge operations
+# ---------------------------------------------------------------------------
 
 async def _start_force_merge_task(es: AsyncElasticsearch, index: str) -> str | None:
     """Submit an async force-merge to 1 segment. Returns the task_id or None on failure."""
@@ -491,151 +551,296 @@ async def _discover_for_force_merge(
     return result
 
 
-async def _do_swap(
-    es: AsyncElasticsearch,
-    state: RunState,
-    src: str,
-) -> str:
-    """Atomically move aliases from src to dst, then delete src. Returns DONE or FAILED."""
-    dst = state.indices[src].dst
+# ---------------------------------------------------------------------------
+# Migration orchestration helpers
+# ---------------------------------------------------------------------------
 
-    aliases = await _get_aliases(es, src)
-    actions: list[dict[str, Any]] = []
-    for alias_name, alias_cfg in aliases.items():
-        add: dict[str, Any] = {"index": dst, "alias": alias_name}
-        if alias_cfg.get("is_write_index"):
-            add["is_write_index"] = True
-        actions.append({"remove": {"index": src, "alias": alias_name}})
-        actions.append({"add": add})
+def _load_or_create_state(
+    args: argparse.Namespace,
+    commit: str,
+    sorted_types: list[str],
+    sorted_explicit: list[str],
+) -> RunState | None:
+    """Load existing or create new migration state. Returns None in dry-run mode.
 
-    if actions:
-        _info(f"  Moving aliases: {', '.join(aliases)}")
-        try:
-            await es.indices.update_aliases(actions=actions)
-        except Exception as exc:
-            _warn(f"  Alias swap failed: {exc}")
-            return FAILED
-
-    try:
-        await es.indices.delete(index=src)
-    except NotFoundError:
-        pass  # Already deleted — idempotent.
-    except Exception as exc:
-        _warn(f"  Delete of {src} failed: {exc}")
-        return FAILED
-
-    return DONE
-
-
-async def _ensure_reindex(
-    es: AsyncElasticsearch,
-    state: RunState,
-    src: str,
-) -> str:
-    """Decide how to (re)start work for src and return the next status.
-
-    Returns REINDEXING (a task is running — poll it), SWAP_PENDING (destination
-    already complete), DONE (destination already live behind an alias), or
-    FAILED (could not start a fresh reindex).
+    Raises ValueError when a state file exists for a different run (mismatched
+    commit or target set). The caller should treat this as a fatal error and
+    tell the user to pass --reset.
     """
-    idx = state.indices[src]
-    dst = idx.dst
+    if args.dry_run:
+        return None
 
-    # 1. A reindex we already know about is still running — re-attach to it.
-    if idx.task_id and await _task_running(es, idx.task_id):
-        _info(f"  Reattaching to running task [cyan]{idx.task_id}[/cyan]")
-        return REINDEXING
+    if args.reset:
+        _warn("--reset: discarding previous state.")
+        STATE_FILE.unlink(missing_ok=True)
+    else:
+        existing = RunState.load()
+        if existing is not None:
+            if sorted_explicit:
+                matches = (existing.commit == commit
+                           and sorted(existing.explicit_indices) == sorted_explicit)
+                desc = f"commit={existing.commit}, indices={existing.explicit_indices}"
+            else:
+                matches = (existing.commit == commit
+                           and sorted(existing.types) == sorted_types)
+                desc = f"commit={existing.commit}, types={existing.types}"
 
-    # 2. An untracked reindex is already writing to dst (e.g. orphaned by an
-    #    earlier Ctrl-C) — adopt it rather than competing with it.
-    orphan = await _find_running_reindex_to(es, dst)
-    if orphan:
-        _info(f"  Adopting running reindex into {dst}: [cyan]{orphan}[/cyan]")
-        state.update(src, task_id=orphan, status=REINDEXING)
-        return REINDEXING
+            if matches:
+                done = sum(1 for s in existing.indices.values() if s.status == DONE)
+                _info(
+                    f"Resuming previous run from {existing.created_at} "
+                    f"({done}/{len(existing.indices)} indices already done)."
+                )
+                return existing
+            else:
+                raise ValueError(
+                    f"State file is for a different run ({desc}). "
+                    f"Use --reset to start fresh."
+                )
 
-    # 3. No reindex running — inspect the destination.
-    if await _index_exists(es, dst):
-        dst_aliases = await _get_aliases(es, dst)
-        if dst_aliases:
-            # Destination already serves an alias — never delete a live index.
-            _info(f"  Destination {dst} already live (aliases: {', '.join(dst_aliases)}).")
-            return DONE
-
-        src_count = await _doc_count(es, src)
-        dst_count = await _doc_count(es, dst)
-        if dst_count is not None and src_count is not None and dst_count >= src_count:
-            _info(f"  Destination {dst} already complete ({dst_count:,}/{src_count:,}) — skipping reindex.")
-            return SWAP_PENDING
-
-        # Alias-less, incomplete leftover — safe to delete and restart fresh.
-        _warn(f"  Removing partial destination {dst} ({dst_count}/{src_count}) and restarting.")
-        try:
-            await es.indices.delete(index=dst)
-        except NotFoundError:
-            pass
-
-    # 4. Start a fresh reindex.
-    return await _start_reindex(es, state, src)
+    state = RunState.create(commit, sorted_types, explicit_indices=sorted_explicit or None)
+    state.save()
+    _info(f"State file: {STATE_FILE}")
+    return state
 
 
-async def _process_index(
+def _classify_for_migration(
+    idx: str,
+    active_index: str | None,
+    state: RunState | None,
+    commit: str,
+) -> bool:
+    """Classify idx and register it in state on first encounter.
+
+    Returns True if the index should be skipped (active write index or
+    already migrated). Also records the skip reason in state so resume
+    runs don't re-evaluate the decision.
+    """
+    # Already registered — let _process_index handle the status (DONE/SKIPPED/etc.)
+    if state is not None and idx in state.indices:
+        return False
+
+    if idx == active_index:
+        if state is not None:
+            state.indices[idx] = IndexState(
+                status=SKIPPED, src=idx, dst=f"{idx}-{commit}", error="active write index",
+            )
+            state.save()
+        _warn(f"Skipping active write index: {idx}")
+        return True
+
+    if _MIGRATED_RE.search(idx):
+        if state is not None:
+            state.indices[idx] = IndexState(
+                status=SKIPPED, src=idx, dst=idx, error="already migrated",
+            )
+            state.save()
+        _info(f"Skipping already-migrated index: {idx}")
+        return True
+
+    if state is not None:
+        state.indices[idx] = IndexState(status=PENDING, src=idx, dst=f"{idx}-{commit}")
+        state.save()
+
+    return False
+
+
+async def _resolve_active_write_index(
+    es: AsyncElasticsearch,
+    cfg: dict[str, str],
+    args: argparse.Namespace,
+    type_name: str,
+) -> str | None:
+    """Return the active write index that should be excluded from migration, or None.
+
+    With --include-active: prompts for confirmation. If the operator confirms,
+    returns None so the index is included. If declined, returns the index name
+    so it is excluded.
+
+    Without --include-active: always returns the active index name (exclude it)
+    and prints a hint about using --indices after rollover.
+    """
+    active = await _active_index_for(es, cfg["active_alias"])
+    if active is None:
+        return None
+
+    if args.include_active:
+        if _confirm_include_active(active, type_name):
+            return None  # confirmed: include it in migration
+        _warn(f"Skipping {type_name} — confirmation declined.")
+        console.print()
+    else:
+        _warn(f"Skipping active {type_name} index: {active}")
+        console.print("  (Use --indices to target it by name after the period rolls over.)")
+        console.print()
+
+    return active
+
+
+async def _migrate_and_maybe_fm(
     es: AsyncElasticsearch,
     state: RunState | None,
-    src: str,
+    idx: str,
     commit: str,
     dry_run: bool,
-) -> None:
-    """Drive one index through its full migration state machine (reindex → swap)."""
-    if dry_run:
-        _info(f"[dim][dry-run][/dim] Would reindex {src} → {src}-{commit}, swap aliases, delete src.")
-        return
+    fire_fm: bool,
+    fm_tasks: dict[str, str],
+) -> bool:
+    """Migrate one index. Returns True on error.
 
-    assert state is not None
-    idx = state.indices[src]
-
-    if idx.status in (DONE, SKIPPED):
-        _info(f"Skipping [{idx.status}]: {src}")
-        return
-
-    _info(f"Migrating [bold]{src}[/bold] → [bold]{idx.dst}[/bold]"
-          + (f" [dim](resuming from {idx.status})[/dim]" if idx.status != PENDING else ""))
-
-    # ── Step 1: ensure a reindex is running, complete, or already live ──────
-    if idx.status in (PENDING, FAILED, REINDEXING):
-        new_status = await _ensure_reindex(es, state, src)
-        if new_status == FAILED:
-            state.update(src, status=FAILED, error="Failed to start reindex")
-            return
-        # Clear any stale error from a previous failed attempt.
-        state.update(src, status=new_status, error=None)
-        if new_status == DONE:
-            state.update(src, completed_at=_now())
-            _info(f"  [green]✓[/green] {src} → {idx.dst} (already migrated)")
-            return
-
-    # ── Step 2: poll until reindex finishes ─────────────────────────────────
-    if state.indices[src].status == REINDEXING:
-        new_status = await _poll_task(es, state, src)
-        state.update(src, status=new_status)
-        if new_status == FAILED:
-            state.update(src, error="Reindex task failed or destination missing after eviction")
-            return
-
-    # ── Step 3: atomic alias swap + delete ──────────────────────────────────
-    if state.indices[src].status == SWAP_PENDING:
-        new_status = await _do_swap(es, state, src)
-        state.update(src, status=new_status, completed_at=_now() if new_status == DONE else None)
-        if new_status == FAILED:
-            state.update(src, error="Alias swap or source deletion failed")
-            return
-
-    _info(f"  [green]✓[/green] {src} → {idx.dst}")
+    If fire_fm is True and migration succeeds, submits a fire-and-forget
+    force-merge (combined --migrate --force-merge mode).
+    """
+    try:
+        await _process_index(es, state, idx, commit, dry_run=dry_run)
+        if state is not None and state.indices.get(idx, IndexState(PENDING, "", "")).status == FAILED:
+            return True
+        if fire_fm and not dry_run and state is not None and state.indices[idx].status == DONE:
+            task_id = await _start_force_merge_task(es, state.indices[idx].dst)
+            if task_id:
+                fm_tasks[state.indices[idx].dst] = task_id
+        return False
+    except Exception as exc:
+        console.print(f"[red][ERROR][/red] {idx}: {exc}")
+        if state is not None:
+            state.update(idx, status=FAILED, error=str(exc))
+        return True
 
 
 # ---------------------------------------------------------------------------
-# Main
+# Command implementations
 # ---------------------------------------------------------------------------
+
+async def _run_migrate(
+    es: AsyncElasticsearch,
+    args: argparse.Namespace,
+    sorted_types: list[str],
+    sorted_explicit: list[str],
+) -> int:
+    """Reindex all target indices and atomically swap their aliases."""
+    commit = args.commit or _git_short_hash()
+    _info(f"Destination suffix: [cyan]{commit}[/cyan]")
+    console.print()
+
+    try:
+        state = _load_or_create_state(args, commit, sorted_types, sorted_explicit)
+    except ValueError as exc:
+        _warn(str(exc))
+        return 1
+
+    if not args.dry_run:
+        console.print()
+
+    errors = 0
+    fm_tasks: dict[str, str] = {}  # dst index → task_id (combined mode fire-and-forget)
+    fire_fm = args.force_merge
+
+    if sorted_explicit:
+        # ── Explicit-index mode: active-index guard is bypassed ──────────────
+        _info("=== Explicit indices (active-index guard bypassed) ===")
+        for idx in sorted_explicit:
+            if _classify_for_migration(idx, None, state, commit):
+                continue
+            if await _migrate_and_maybe_fm(es, state, idx, commit, args.dry_run, fire_fm, fm_tasks):
+                errors += 1
+        console.print()
+
+    else:
+        # ── Type-discovery mode: discover and skip the active write index ────
+        for type_name in sorted_types:
+            cfg = INDEX_TYPES[type_name]
+            active_index = await _resolve_active_write_index(es, cfg, args, type_name)
+
+            _info(f"=== {cfg['pattern']} (newest first) ===")
+            indices = await _list_indices(es, cfg["pattern"])
+            if not indices:
+                _info(f"No indices found matching {cfg['pattern']}")
+                console.print()
+                continue
+
+            for idx in indices:
+                if _classify_for_migration(idx, active_index, state, commit):
+                    continue
+                if await _migrate_and_maybe_fm(es, state, idx, commit, args.dry_run, fire_fm, fm_tasks):
+                    errors += 1
+
+            console.print()
+
+    if errors:
+        console.print(
+            f"[red][ERROR][/red] Migration finished with {errors} error(s). "
+            f"Review output above, then re-run to retry failed indices."
+        )
+        return 1
+
+    if state is not None:
+        STATE_FILE.unlink(missing_ok=True)
+        _info("State file removed (migration complete).")
+
+    await _print_alias_summary(es)
+    console.print()
+    _info("Migration complete.")
+    console.print()
+    console.print(
+        "[yellow][WARN][/yellow]  ILM note: migrated indices have a new creation date, so their "
+        "ILM deletion timer resets to zero. If storage capacity is a concern, manually delete "
+        "migrated indices for periods that have already expired under your retention policy:\n"
+        "  DELETE /<index-name>  (e.g. via Kibana Dev Tools or curl)"
+    )
+
+    if fm_tasks:
+        console.print()
+        _warn(
+            f"{len(fm_tasks)} force-merge task(s) are running in the background "
+            f"(submitted after each alias swap, not waited on):"
+        )
+        for dst, tid in fm_tasks.items():
+            console.print(f"  [bold]{dst}[/bold]: [cyan]{tid}[/cyan]")
+        console.print(
+            "  Monitor progress: GET /_tasks/<task_id>\n"
+            "  Or run --force-merge --indices <name> to poll with progress."
+        )
+
+    return 0
+
+
+async def _run_force_merge(
+    es: AsyncElasticsearch,
+    args: argparse.Namespace,
+    sorted_types: list[str],
+    sorted_explicit: list[str],
+) -> int:
+    """Submit async force-merges for all targets and poll until complete."""
+    _info("=== Force-merge ===")
+    console.print()
+
+    targets = sorted_explicit or await _discover_for_force_merge(es, sorted_types)
+
+    if not targets:
+        _info("No indices to force-merge.")
+        return 0
+
+    if args.dry_run:
+        for idx in targets:
+            _info(f"[dim][dry-run][/dim] Would force-merge {idx} to 1 segment.")
+        return 0
+
+    fm_tasks: dict[str, str] = {}
+    for idx in targets:
+        task_id = await _start_force_merge_task(es, idx)
+        if task_id:
+            fm_tasks[idx] = task_id
+    console.print()
+
+    if fm_tasks:
+        _info(f"Polling {len(fm_tasks)} force-merge task(s) ...")
+        console.print()
+        await _poll_all_force_merges(es, fm_tasks)
+        console.print()
+
+    _info("Force-merge complete.")
+    return 0
+
 
 async def _print_alias_summary(es: AsyncElasticsearch) -> None:
     """Print which index each key alias currently points to."""
@@ -655,11 +860,15 @@ async def _print_alias_summary(es: AsyncElasticsearch) -> None:
             console.print(f"  [cyan]{alias}[/cyan] → [dim](insufficient privileges)[/dim]")
 
 
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
 async def _run(args: argparse.Namespace) -> int:
     if not args.migrate and not args.force_merge:
         _die("Specify at least one operation: --migrate and/or --force-merge.")
 
-    url = os.environ.get("GE_ELASTICSEARCH_URL", "https://localhost:9200")
+    url      = os.environ.get("GE_ELASTICSEARCH_URL", "https://localhost:9200")
     username = os.environ.get("GE_ELASTICSEARCH_USERNAME", "elastic")
     password = os.environ.get("GE_ELASTICSEARCH_PASSWORD")
     skip_tls = os.environ.get("GE_ELASTICSEARCH_TLS_SKIP_VERIFY", "false").lower() in (
@@ -680,241 +889,20 @@ async def _run(args: argparse.Namespace) -> int:
         _info(f"Connected to Elasticsearch {info['version']['number']} at {url}")
         console.print()
 
-        sorted_types = sorted(args.types or [])
+        sorted_types    = sorted(args.types or [])
         sorted_explicit = sorted(args.indices or [])
 
         if args.dry_run:
             _warn("Dry-run mode — no changes will be made and state will not be saved.")
         console.print()
 
-        # ── Migration ────────────────────────────────────────────────────────
         if args.migrate:
-            commit = args.commit or _git_short_hash()
-            _info(f"Destination suffix: [cyan]{commit}[/cyan]")
-            console.print()
+            rc = await _run_migrate(es, args, sorted_types, sorted_explicit)
+            if rc != 0:
+                return rc
 
-            # ── State init ───────────────────────────────────────────────────
-            state: RunState | None = None
-
-            if not args.dry_run:
-                if args.reset:
-                    _warn("--reset: discarding previous state.")
-                    STATE_FILE.unlink(missing_ok=True)
-                else:
-                    state = RunState.load()
-                    if state is not None:
-                        if sorted_explicit:
-                            state_matches = (
-                                state.commit == commit
-                                and sorted(state.explicit_indices) == sorted_explicit
-                            )
-                            state_desc = f"commit={state.commit}, indices={state.explicit_indices}"
-                        else:
-                            state_matches = (
-                                state.commit == commit
-                                and sorted(state.types) == sorted_types
-                            )
-                            state_desc = f"commit={state.commit}, types={state.types}"
-
-                        if state_matches:
-                            done = sum(1 for s in state.indices.values() if s.status == DONE)
-                            total_tracked = len(state.indices)
-                            _info(
-                                f"Resuming previous run from {state.created_at} "
-                                f"({done}/{total_tracked} indices already done)."
-                            )
-                        else:
-                            _warn(
-                                f"State file is for a different run ({state_desc}). "
-                                f"Use --reset to start fresh."
-                            )
-                            return 1
-
-                if state is None:
-                    state = RunState.create(commit, sorted_types, explicit_indices=sorted_explicit or None)
-                    state.save()
-                    _info(f"State file: {STATE_FILE}")
-
-                console.print()
-
-            errors = 0
-            # fm_tasks: destination index → task_id for fire-and-forget FMs (combined mode)
-            fm_tasks: dict[str, str] = {}
-
-            async def _migrate_one(idx: str) -> None:
-                """Register idx in state (if needed), migrate it, then fire FM if combined."""
-                nonlocal errors
-                try:
-                    await _process_index(es, state, idx, commit, dry_run=args.dry_run)
-                    if state is not None and state.indices.get(idx, IndexState("", "", "")).status == FAILED:
-                        errors += 1
-                        return
-                    if args.force_merge and not args.dry_run:
-                        dst = state.indices[idx].dst if state else f"{idx}-{commit}"
-                        if state is None or state.indices[idx].status == DONE:
-                            task_id = await _start_force_merge_task(es, dst)
-                            if task_id:
-                                fm_tasks[dst] = task_id
-                except Exception as exc:
-                    console.print(f"[red][ERROR][/red] {idx}: {exc}")
-                    if state is not None:
-                        state.update(idx, status=FAILED, error=str(exc))
-                    errors += 1
-
-            if sorted_explicit:
-                # ── Explicit-index mode ──────────────────────────────────────
-                _info("=== Explicit indices (active-index guard bypassed) ===")
-                for idx in sorted_explicit:
-                    if state is not None and idx not in state.indices:
-                        if _MIGRATED_RE.search(idx):
-                            state.indices[idx] = IndexState(
-                                status=SKIPPED, src=idx, dst=idx, error="already migrated",
-                            )
-                            state.save()
-                            _info(f"Skipping already-migrated index: {idx}")
-                            continue
-                        state.indices[idx] = IndexState(
-                            status=PENDING, src=idx, dst=f"{idx}-{commit}",
-                        )
-                        state.save()
-                    else:
-                        if _MIGRATED_RE.search(idx) and (state is None or idx not in state.indices):
-                            _info(f"Skipping already-migrated index: {idx}")
-                            continue
-                    await _migrate_one(idx)
-                console.print()
-
-            else:
-                # ── Type-discovery mode ──────────────────────────────────────
-                for type_name in sorted_types:
-                    cfg = INDEX_TYPES[type_name]
-                    pattern = cfg["pattern"]
-                    active_alias = cfg["active_alias"]
-
-                    active_index: str | None = None
-                    if args.include_active:
-                        active_index = await _active_index_for(es, active_alias)
-                        if active_index and not _confirm_include_active(active_index, type_name):
-                            _warn(f"Skipping {type_name} — confirmation declined.")
-                            console.print()
-                            active_index = None
-                    else:
-                        active_index = await _active_index_for(es, active_alias)
-                        if active_index:
-                            _warn(f"Skipping active {type_name} index: {active_index}")
-                            console.print(
-                                "  (Use --indices to target it by name after the period rolls over.)"
-                            )
-                            console.print()
-
-                    _info(f"=== {pattern} (newest first) ===")
-                    indices = await _list_indices(es, pattern)
-                    if not indices:
-                        _info(f"No indices found matching {pattern}")
-                        console.print()
-                        continue
-
-                    for idx in indices:
-                        if state is not None and idx not in state.indices:
-                            if idx == active_index:
-                                state.indices[idx] = IndexState(
-                                    status=SKIPPED, src=idx, dst=f"{idx}-{commit}",
-                                    error="active write index",
-                                )
-                                state.save()
-                                _warn(f"Skipping active index: {idx}")
-                                continue
-                            if _MIGRATED_RE.search(idx):
-                                state.indices[idx] = IndexState(
-                                    status=SKIPPED, src=idx, dst=idx, error="already migrated",
-                                )
-                                state.save()
-                                _info(f"Skipping already-migrated index: {idx}")
-                                continue
-                            state.indices[idx] = IndexState(
-                                status=PENDING, src=idx, dst=f"{idx}-{commit}",
-                            )
-                            state.save()
-                        else:
-                            if idx == active_index:
-                                _warn(f"Skipping active index: {idx}")
-                                continue
-                            if _MIGRATED_RE.search(idx) and (state is None or idx not in state.indices):
-                                _info(f"Skipping already-migrated index: {idx}")
-                                continue
-                        await _migrate_one(idx)
-
-                    console.print()
-
-            if errors:
-                console.print(
-                    f"[red][ERROR][/red] Migration finished with {errors} error(s). "
-                    f"Review output above, then re-run to retry failed indices."
-                )
-                return 1
-
-            if state is not None:
-                STATE_FILE.unlink(missing_ok=True)
-                _info("State file removed (migration complete).")
-
-            await _print_alias_summary(es)
-            console.print()
-            _info("Migration complete.")
-            console.print()
-            console.print(
-                "[yellow][WARN][/yellow]  ILM note: migrated indices have a new creation date, so their "
-                "ILM deletion timer resets to zero. If storage capacity is a concern, manually delete "
-                "migrated indices for periods that have already expired under your retention policy:\n"
-                "  DELETE /<index-name>  (e.g. via Kibana Dev Tools or curl)"
-            )
-
-            # In combined mode, report fire-and-forget FM tasks still running in background.
-            if fm_tasks:
-                console.print()
-                _warn(
-                    f"{len(fm_tasks)} force-merge task(s) are running in the background "
-                    f"(submitted after each alias swap, not waited on):"
-                )
-                for dst, tid in fm_tasks.items():
-                    console.print(f"  [bold]{dst}[/bold]: [cyan]{tid}[/cyan]")
-                console.print(
-                    "  Monitor progress: GET /_tasks/<task_id>\n"
-                    "  Or run --force-merge --indices <name> to poll with progress."
-                )
-
-        # ── Force-merge only ─────────────────────────────────────────────────
-        else:
-            _info("=== Force-merge ===")
-            console.print()
-
-            if sorted_explicit:
-                targets = sorted_explicit
-            else:
-                targets = await _discover_for_force_merge(es, sorted_types)
-
-            if not targets:
-                _info("No indices to force-merge.")
-                return 0
-
-            if args.dry_run:
-                for idx in targets:
-                    _info(f"[dim][dry-run][/dim] Would force-merge {idx} to 1 segment.")
-                return 0
-
-            fm_tasks = {}
-            for idx in targets:
-                task_id = await _start_force_merge_task(es, idx)
-                if task_id:
-                    fm_tasks[idx] = task_id
-            console.print()
-
-            if fm_tasks:
-                _info(f"Polling {len(fm_tasks)} force-merge task(s) ...")
-                console.print()
-                await _poll_all_force_merges(es, fm_tasks)
-                console.print()
-
-            _info("Force-merge complete.")
+        if args.force_merge and not args.migrate:
+            return await _run_force_merge(es, args, sorted_types, sorted_explicit)
 
         return 0
 

--- a/tools/reindex.py
+++ b/tools/reindex.py
@@ -21,6 +21,7 @@ Run from the tools/ directory:
     pipenv run python reindex.py --types posts replies --dry-run
     pipenv run python reindex.py --types posts replies --include-active
     pipenv run python reindex.py --types posts replies likes
+    pipenv run python reindex.py --types posts replies --force-merge
 
 Prerequisites:
   - Updated ILM templates have been deployed (bootstrap job or manual PUT).
@@ -381,6 +382,16 @@ async def _start_reindex(
     return REINDEXING
 
 
+async def _force_merge_index(es: AsyncElasticsearch, index: str) -> None:
+    """Force-merge index to a single segment. Blocks until complete; non-fatal on error."""
+    _info(f"  Force-merging {index} to 1 segment (this may take a while) ...")
+    try:
+        await es.indices.forcemerge(index=index, max_num_segments=1, wait_for_completion=True)
+        _info(f"  Force-merge complete.")
+    except Exception as exc:
+        _warn(f"  Force-merge failed (non-fatal, alias swap will still proceed): {exc}")
+
+
 async def _do_swap(
     es: AsyncElasticsearch,
     state: RunState,
@@ -475,10 +486,12 @@ async def _process_index(
     src: str,
     commit: str,
     dry_run: bool,
+    force_merge: bool = False,
 ) -> None:
     """Drive one index through its full migration state machine."""
     if dry_run:
-        _info(f"[dim][dry-run][/dim] Would reindex {src} → {src}-{commit}, swap aliases, delete src.")
+        fm_note = ", force-merge to 1 segment" if force_merge else ""
+        _info(f"[dim][dry-run][/dim] Would reindex {src} → {src}-{commit}{fm_note}, swap aliases, delete src.")
         return
 
     assert state is not None
@@ -511,6 +524,10 @@ async def _process_index(
         if new_status == FAILED:
             state.update(src, error="Reindex task failed or destination missing after eviction")
             return
+
+    # ── Step 2.5: optional force-merge before swap ───────────────────────────
+    if state.indices[src].status == SWAP_PENDING and force_merge:
+        await _force_merge_index(es, state.indices[src].dst)
 
     # ── Step 3: atomic alias swap + delete ──────────────────────────────────
     if state.indices[src].status == SWAP_PENDING:
@@ -666,7 +683,7 @@ async def _run(args: argparse.Namespace) -> int:
                         continue
 
                 try:
-                    await _process_index(es, state, idx, commit, dry_run=args.dry_run)
+                    await _process_index(es, state, idx, commit, dry_run=args.dry_run, force_merge=args.force_merge)
                     if state is not None and state.indices[idx].status == FAILED:
                         errors += 1
                 except Exception as exc:
@@ -713,6 +730,7 @@ examples:
   pipenv run python reindex.py --types posts replies --dry-run
   pipenv run python reindex.py --types posts replies --include-active
   pipenv run python reindex.py --types posts replies likes
+  pipenv run python reindex.py --types posts replies --force-merge
   pipenv run python reindex.py --types posts --reset
 """,
     )
@@ -745,6 +763,15 @@ examples:
         "--commit",
         metavar="HASH",
         help="Override the git commit hash used as the destination index suffix.",
+    )
+    parser.add_argument(
+        "--force-merge",
+        action="store_true",
+        help=(
+            "After each reindex completes, force-merge the destination index to 1 segment "
+            "before swapping aliases. Reduces per-shard term-seek cost immediately rather "
+            "than waiting for the ILM warm phase. Heavy I/O — run off-peak."
+        ),
     )
     parser.add_argument(
         "--reset",

--- a/tools/reindex.py
+++ b/tools/reindex.py
@@ -18,10 +18,11 @@ re-run with the same --types flags and the same commit in the working tree;
 the script will skip completed indices and pick up where it left off.
 
 Run from the tools/ directory:
-    pipenv run python reindex.py --types posts replies --dry-run
-    pipenv run python reindex.py --types posts replies --force-merge
-    pipenv run python reindex.py --indices posts-2026-w26 replies-2026-w26
-    pipenv run python reindex.py --types posts replies --include-active
+    pipenv run python reindex.py --migrate --types posts replies --dry-run
+    pipenv run python reindex.py --migrate --types posts replies
+    pipenv run python reindex.py --migrate --force-merge --types posts replies
+    pipenv run python reindex.py --force-merge --types posts replies
+    pipenv run python reindex.py --migrate --indices posts-2026-w26 replies-2026-w26
 
 Prerequisites:
   - Updated ILM templates have been deployed (bootstrap job or manual PUT).
@@ -419,14 +420,75 @@ async def _start_reindex(
     return REINDEXING
 
 
-async def _force_merge_index(es: AsyncElasticsearch, index: str) -> None:
-    """Force-merge index to a single segment. Blocks until complete; non-fatal on error."""
-    _info(f"  Force-merging {index} to 1 segment (this may take a while) ...")
+async def _start_force_merge_task(es: AsyncElasticsearch, index: str) -> str | None:
+    """Submit an async force-merge to 1 segment. Returns the task_id or None on failure."""
+    _info(f"  Submitting force-merge for [bold]{index}[/bold] ...")
     try:
-        await es.indices.forcemerge(index=index, max_num_segments=1, wait_for_completion=True)
-        _info(f"  Force-merge complete.")
+        resp = await es.indices.forcemerge(index=index, max_num_segments=1, wait_for_completion=False)
+        task_id: str = resp["task"]
+        _info(f"  Task: [cyan]{task_id}[/cyan]")
+        return task_id
     except Exception as exc:
-        _warn(f"  Force-merge failed (non-fatal, alias swap will still proceed): {exc}")
+        _warn(f"  Failed to submit force-merge for {index}: {exc}")
+        return None
+
+
+async def _poll_all_force_merges(
+    es: AsyncElasticsearch,
+    tasks: dict[str, str],
+) -> None:
+    """Poll a set of async force-merge tasks concurrently until all complete. Non-fatal on errors."""
+    pending = dict(tasks)  # index → task_id
+    while pending:
+        await asyncio.sleep(POLL_INTERVAL_SECS)
+        done: list[str] = []
+        for idx, task_id in pending.items():
+            try:
+                task = await es.tasks.get(task_id=task_id)
+            except NotFoundError:
+                _warn(f"  {idx}: task evicted — assuming complete.")
+                done.append(idx)
+                continue
+
+            completed: bool = task.get("completed") is True
+            running_nanos = task.get("task", {}).get("running_time_in_nanos", 0)
+            _info(f"  {idx}: running {running_nanos / 1e9:.0f}s ...")
+
+            if completed:
+                failures = (task.get("response") or {}).get("_shards", {}).get("failures") or []
+                if failures:
+                    _warn(f"  {idx}: complete with {len(failures)} shard failure(s) (non-fatal):")
+                    for f in failures:
+                        console.print(f"    {f}")
+                else:
+                    _info(f"  [green]✓[/green] {idx}: force-merge complete.")
+                done.append(idx)
+
+        for idx in done:
+            del pending[idx]
+
+
+async def _discover_for_force_merge(
+    es: AsyncElasticsearch,
+    sorted_types: list[str],
+) -> list[str]:
+    """Discover all non-active indices for the given types (newest first per type).
+
+    Force-merging the active write index is wasteful — new segments are created
+    continuously — so it is always skipped here. Use --indices to target a
+    specific index by name if needed.
+    """
+    result: list[str] = []
+    for type_name in sorted_types:
+        cfg = INDEX_TYPES[type_name]
+        active = await _active_index_for(es, cfg["active_alias"])
+        indices = await _list_indices(es, cfg["pattern"])
+        for idx in indices:
+            if idx == active:
+                _warn(f"Skipping active write index {idx} (force-merging it is wasteful).")
+                continue
+            result.append(idx)
+    return result
 
 
 async def _do_swap(
@@ -523,12 +585,10 @@ async def _process_index(
     src: str,
     commit: str,
     dry_run: bool,
-    force_merge: bool = False,
 ) -> None:
-    """Drive one index through its full migration state machine."""
+    """Drive one index through its full migration state machine (reindex → swap)."""
     if dry_run:
-        fm_note = ", force-merge to 1 segment" if force_merge else ""
-        _info(f"[dim][dry-run][/dim] Would reindex {src} → {src}-{commit}{fm_note}, swap aliases, delete src.")
+        _info(f"[dim][dry-run][/dim] Would reindex {src} → {src}-{commit}, swap aliases, delete src.")
         return
 
     assert state is not None
@@ -561,10 +621,6 @@ async def _process_index(
         if new_status == FAILED:
             state.update(src, error="Reindex task failed or destination missing after eviction")
             return
-
-    # ── Step 2.5: optional force-merge before swap ───────────────────────────
-    if state.indices[src].status == SWAP_PENDING and force_merge:
-        await _force_merge_index(es, state.indices[src].dst)
 
     # ── Step 3: atomic alias swap + delete ──────────────────────────────────
     if state.indices[src].status == SWAP_PENDING:
@@ -600,6 +656,9 @@ async def _print_alias_summary(es: AsyncElasticsearch) -> None:
 
 
 async def _run(args: argparse.Namespace) -> int:
+    if not args.migrate and not args.force_merge:
+        _die("Specify at least one operation: --migrate and/or --force-merge.")
+
     url = os.environ.get("GE_ELASTICSEARCH_URL", "https://localhost:9200")
     username = os.environ.get("GE_ELASTICSEARCH_USERNAME", "elastic")
     password = os.environ.get("GE_ELASTICSEARCH_PASSWORD")
@@ -621,144 +680,95 @@ async def _run(args: argparse.Namespace) -> int:
         _info(f"Connected to Elasticsearch {info['version']['number']} at {url}")
         console.print()
 
-        commit = args.commit or _git_short_hash()
-        _info(f"Destination suffix: [cyan]{commit}[/cyan]")
+        sorted_types = sorted(args.types or [])
+        sorted_explicit = sorted(args.indices or [])
 
         if args.dry_run:
             _warn("Dry-run mode — no changes will be made and state will not be saved.")
         console.print()
 
-        # ── State init ───────────────────────────────────────────────────────
-        sorted_types = sorted(args.types or [])
-        sorted_explicit = sorted(args.indices or [])
-        state: RunState | None = None
-
-        if not args.dry_run:
-            if args.reset:
-                _warn("--reset: discarding previous state.")
-                STATE_FILE.unlink(missing_ok=True)
-            else:
-                state = RunState.load()
-                if state is not None:
-                    if sorted_explicit:
-                        state_matches = (
-                            state.commit == commit
-                            and sorted(state.explicit_indices) == sorted_explicit
-                        )
-                        state_desc = f"commit={state.commit}, indices={state.explicit_indices}"
-                    else:
-                        state_matches = (
-                            state.commit == commit
-                            and sorted(state.types) == sorted_types
-                        )
-                        state_desc = f"commit={state.commit}, types={state.types}"
-
-                    if state_matches:
-                        done = sum(1 for s in state.indices.values() if s.status == DONE)
-                        total_tracked = len(state.indices)
-                        _info(
-                            f"Resuming previous run from {state.created_at} "
-                            f"({done}/{total_tracked} indices already done)."
-                        )
-                    else:
-                        _warn(
-                            f"State file is for a different run ({state_desc}). "
-                            f"Use --reset to start fresh."
-                        )
-                        return 1
-
-            if state is None:
-                state = RunState.create(commit, sorted_types, explicit_indices=sorted_explicit or None)
-                state.save()
-                _info(f"State file: {STATE_FILE}")
-
+        # ── Migration ────────────────────────────────────────────────────────
+        if args.migrate:
+            commit = args.commit or _git_short_hash()
+            _info(f"Destination suffix: [cyan]{commit}[/cyan]")
             console.print()
 
-        # ── Discover and process indices ─────────────────────────────────────
-        errors = 0
+            # ── State init ───────────────────────────────────────────────────
+            state: RunState | None = None
 
-        if sorted_explicit:
-            # ── Explicit-index mode: process only the named indices ──────────
-            _info(f"=== Explicit indices (active-index guard bypassed) ===")
-
-            for idx in sorted_explicit:
-                if state is not None and idx not in state.indices:
-                    if _MIGRATED_RE.search(idx):
-                        state.indices[idx] = IndexState(
-                            status=SKIPPED, src=idx, dst=idx,
-                            error="already migrated",
-                        )
-                        state.save()
-                        _info(f"Skipping already-migrated index: {idx}")
-                        continue
-                    state.indices[idx] = IndexState(
-                        status=PENDING, src=idx, dst=f"{idx}-{commit}",
-                    )
-                    state.save()
+            if not args.dry_run:
+                if args.reset:
+                    _warn("--reset: discarding previous state.")
+                    STATE_FILE.unlink(missing_ok=True)
                 else:
-                    if _MIGRATED_RE.search(idx) and (state is None or idx not in state.indices):
-                        _info(f"Skipping already-migrated index: {idx}")
-                        continue
+                    state = RunState.load()
+                    if state is not None:
+                        if sorted_explicit:
+                            state_matches = (
+                                state.commit == commit
+                                and sorted(state.explicit_indices) == sorted_explicit
+                            )
+                            state_desc = f"commit={state.commit}, indices={state.explicit_indices}"
+                        else:
+                            state_matches = (
+                                state.commit == commit
+                                and sorted(state.types) == sorted_types
+                            )
+                            state_desc = f"commit={state.commit}, types={state.types}"
 
+                        if state_matches:
+                            done = sum(1 for s in state.indices.values() if s.status == DONE)
+                            total_tracked = len(state.indices)
+                            _info(
+                                f"Resuming previous run from {state.created_at} "
+                                f"({done}/{total_tracked} indices already done)."
+                            )
+                        else:
+                            _warn(
+                                f"State file is for a different run ({state_desc}). "
+                                f"Use --reset to start fresh."
+                            )
+                            return 1
+
+                if state is None:
+                    state = RunState.create(commit, sorted_types, explicit_indices=sorted_explicit or None)
+                    state.save()
+                    _info(f"State file: {STATE_FILE}")
+
+                console.print()
+
+            errors = 0
+            # fm_tasks: destination index → task_id for fire-and-forget FMs (combined mode)
+            fm_tasks: dict[str, str] = {}
+
+            async def _migrate_one(idx: str) -> None:
+                """Register idx in state (if needed), migrate it, then fire FM if combined."""
+                nonlocal errors
                 try:
-                    await _process_index(es, state, idx, commit, dry_run=args.dry_run, force_merge=args.force_merge)
-                    if state is not None and state.indices[idx].status == FAILED:
+                    await _process_index(es, state, idx, commit, dry_run=args.dry_run)
+                    if state is not None and state.indices.get(idx, IndexState("", "", "")).status == FAILED:
                         errors += 1
+                        return
+                    if args.force_merge and not args.dry_run:
+                        dst = state.indices[idx].dst if state else f"{idx}-{commit}"
+                        if state is None or state.indices[idx].status == DONE:
+                            task_id = await _start_force_merge_task(es, dst)
+                            if task_id:
+                                fm_tasks[dst] = task_id
                 except Exception as exc:
                     console.print(f"[red][ERROR][/red] {idx}: {exc}")
                     if state is not None:
                         state.update(idx, status=FAILED, error=str(exc))
                     errors += 1
 
-            console.print()
-
-        else:
-            # ── Type-discovery mode: pattern-scan per type ───────────────────
-            for type_name in sorted_types:
-                cfg = INDEX_TYPES[type_name]
-                pattern = cfg["pattern"]
-                active_alias = cfg["active_alias"]
-
-                active_index: str | None = None
-                if args.include_active:
-                    active_index = await _active_index_for(es, active_alias)
-                    if active_index and not _confirm_include_active(active_index, type_name):
-                        _warn(f"Skipping {type_name} — confirmation declined.")
-                        console.print()
-                        active_index = None  # treat as if --include-active not set for this type
-                        # fall through: pattern discovery will still skip it via active_index guard below
-                else:
-                    active_index = await _active_index_for(es, active_alias)
-                    if active_index:
-                        _warn(f"Skipping active {type_name} index: {active_index}")
-                        console.print(
-                            "  (Use --indices to target it by name after the period rolls over.)"
-                        )
-                        console.print()
-
-                _info(f"=== {pattern} (newest first) ===")
-                indices = await _list_indices(es, pattern)
-
-                if not indices:
-                    _info(f"No indices found matching {pattern}")
-                    console.print()
-                    continue
-
-                for idx in indices:
-                    # Register indices in state on first encounter (non-dry-run).
+            if sorted_explicit:
+                # ── Explicit-index mode ──────────────────────────────────────
+                _info("=== Explicit indices (active-index guard bypassed) ===")
+                for idx in sorted_explicit:
                     if state is not None and idx not in state.indices:
-                        if idx == active_index:
-                            state.indices[idx] = IndexState(
-                                status=SKIPPED, src=idx, dst=f"{idx}-{commit}",
-                                error="active write index",
-                            )
-                            state.save()
-                            _warn(f"Skipping active index: {idx}")
-                            continue
                         if _MIGRATED_RE.search(idx):
                             state.indices[idx] = IndexState(
-                                status=SKIPPED, src=idx, dst=idx,
-                                error="already migrated",
+                                status=SKIPPED, src=idx, dst=idx, error="already migrated",
                             )
                             state.save()
                             _info(f"Skipping already-migrated index: {idx}")
@@ -768,47 +778,144 @@ async def _run(args: argparse.Namespace) -> int:
                         )
                         state.save()
                     else:
-                        # Dry-run or already in state: apply simple guards.
-                        if idx == active_index:
-                            _warn(f"Skipping active index: {idx}")
-                            continue
                         if _MIGRATED_RE.search(idx) and (state is None or idx not in state.indices):
                             _info(f"Skipping already-migrated index: {idx}")
                             continue
-
-                    try:
-                        await _process_index(es, state, idx, commit, dry_run=args.dry_run, force_merge=args.force_merge)
-                        if state is not None and state.indices[idx].status == FAILED:
-                            errors += 1
-                    except Exception as exc:
-                        console.print(f"[red][ERROR][/red] {idx}: {exc}")
-                        if state is not None:
-                            state.update(idx, status=FAILED, error=str(exc))
-                        errors += 1
-
+                    await _migrate_one(idx)
                 console.print()
 
-        if errors:
+            else:
+                # ── Type-discovery mode ──────────────────────────────────────
+                for type_name in sorted_types:
+                    cfg = INDEX_TYPES[type_name]
+                    pattern = cfg["pattern"]
+                    active_alias = cfg["active_alias"]
+
+                    active_index: str | None = None
+                    if args.include_active:
+                        active_index = await _active_index_for(es, active_alias)
+                        if active_index and not _confirm_include_active(active_index, type_name):
+                            _warn(f"Skipping {type_name} — confirmation declined.")
+                            console.print()
+                            active_index = None
+                    else:
+                        active_index = await _active_index_for(es, active_alias)
+                        if active_index:
+                            _warn(f"Skipping active {type_name} index: {active_index}")
+                            console.print(
+                                "  (Use --indices to target it by name after the period rolls over.)"
+                            )
+                            console.print()
+
+                    _info(f"=== {pattern} (newest first) ===")
+                    indices = await _list_indices(es, pattern)
+                    if not indices:
+                        _info(f"No indices found matching {pattern}")
+                        console.print()
+                        continue
+
+                    for idx in indices:
+                        if state is not None and idx not in state.indices:
+                            if idx == active_index:
+                                state.indices[idx] = IndexState(
+                                    status=SKIPPED, src=idx, dst=f"{idx}-{commit}",
+                                    error="active write index",
+                                )
+                                state.save()
+                                _warn(f"Skipping active index: {idx}")
+                                continue
+                            if _MIGRATED_RE.search(idx):
+                                state.indices[idx] = IndexState(
+                                    status=SKIPPED, src=idx, dst=idx, error="already migrated",
+                                )
+                                state.save()
+                                _info(f"Skipping already-migrated index: {idx}")
+                                continue
+                            state.indices[idx] = IndexState(
+                                status=PENDING, src=idx, dst=f"{idx}-{commit}",
+                            )
+                            state.save()
+                        else:
+                            if idx == active_index:
+                                _warn(f"Skipping active index: {idx}")
+                                continue
+                            if _MIGRATED_RE.search(idx) and (state is None or idx not in state.indices):
+                                _info(f"Skipping already-migrated index: {idx}")
+                                continue
+                        await _migrate_one(idx)
+
+                    console.print()
+
+            if errors:
+                console.print(
+                    f"[red][ERROR][/red] Migration finished with {errors} error(s). "
+                    f"Review output above, then re-run to retry failed indices."
+                )
+                return 1
+
+            if state is not None:
+                STATE_FILE.unlink(missing_ok=True)
+                _info("State file removed (migration complete).")
+
+            await _print_alias_summary(es)
+            console.print()
+            _info("Migration complete.")
+            console.print()
             console.print(
-                f"[red][ERROR][/red] Migration finished with {errors} error(s). "
-                f"Review output above, then re-run to retry failed indices."
+                "[yellow][WARN][/yellow]  ILM note: migrated indices have a new creation date, so their "
+                "ILM deletion timer resets to zero. If storage capacity is a concern, manually delete "
+                "migrated indices for periods that have already expired under your retention policy:\n"
+                "  DELETE /<index-name>  (e.g. via Kibana Dev Tools or curl)"
             )
-            return 1
 
-        if state is not None:
-            STATE_FILE.unlink(missing_ok=True)
-            _info(f"State file removed (migration complete).")
+            # In combined mode, report fire-and-forget FM tasks still running in background.
+            if fm_tasks:
+                console.print()
+                _warn(
+                    f"{len(fm_tasks)} force-merge task(s) are running in the background "
+                    f"(submitted after each alias swap, not waited on):"
+                )
+                for dst, tid in fm_tasks.items():
+                    console.print(f"  [bold]{dst}[/bold]: [cyan]{tid}[/cyan]")
+                console.print(
+                    "  Monitor progress: GET /_tasks/<task_id>\n"
+                    "  Or run --force-merge --indices <name> to poll with progress."
+                )
 
-        await _print_alias_summary(es)
-        console.print()
-        _info("Migration complete.")
-        console.print()
-        console.print(
-            "[yellow][WARN][/yellow]  ILM note: migrated indices have a new creation date, so their "
-            "ILM deletion timer resets to zero. If storage capacity is a concern, manually delete "
-            "migrated indices for periods that have already expired under your retention policy:\n"
-            "  DELETE /<index-name>  (e.g. via Kibana Dev Tools or curl)"
-        )
+        # ── Force-merge only ─────────────────────────────────────────────────
+        else:
+            _info("=== Force-merge ===")
+            console.print()
+
+            if sorted_explicit:
+                targets = sorted_explicit
+            else:
+                targets = await _discover_for_force_merge(es, sorted_types)
+
+            if not targets:
+                _info("No indices to force-merge.")
+                return 0
+
+            if args.dry_run:
+                for idx in targets:
+                    _info(f"[dim][dry-run][/dim] Would force-merge {idx} to 1 segment.")
+                return 0
+
+            fm_tasks = {}
+            for idx in targets:
+                task_id = await _start_force_merge_task(es, idx)
+                if task_id:
+                    fm_tasks[idx] = task_id
+            console.print()
+
+            if fm_tasks:
+                _info(f"Polling {len(fm_tasks)} force-merge task(s) ...")
+                console.print()
+                await _poll_all_force_merges(es, fm_tasks)
+                console.print()
+
+            _info("Force-merge complete.")
+
         return 0
 
     finally:
@@ -817,24 +924,55 @@ async def _run(args: argparse.Namespace) -> int:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Reindex Elasticsearch indices to pick up updated mappings.",
+        description=(
+            "Reindex and/or force-merge Elasticsearch indices.\n"
+            "At least one of --migrate / --force-merge must be specified."
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 examples:
-  # Reindex all historical (non-active) posts and replies indices
-  pipenv run python reindex.py --types posts replies --dry-run
-  pipenv run python reindex.py --types posts replies --force-merge
+  # Migration only — reindex historical indices and swap aliases
+  pipenv run python reindex.py --migrate --types posts replies --dry-run
+  pipenv run python reindex.py --migrate --types posts replies
+  pipenv run python reindex.py --migrate --indices posts-2026-w26 replies-2026-w26
 
-  # After rollover: reindex the formerly-active index by name (no confirmation prompt)
-  pipenv run python reindex.py --indices posts-2026-w26 replies-2026-w26
+  # Force-merge only — submit async, poll with progress (run off-peak)
+  pipenv run python reindex.py --force-merge --types posts replies
+  pipenv run python reindex.py --force-merge --indices posts-2026-w25-abc1234
+
+  # Combined — migrate then fire-and-forget force-merge (runs concurrently with next index)
+  pipenv run python reindex.py --migrate --force-merge --types posts replies
 
   # Reindex the active write index (requires confirmation; stop ingest services first)
-  pipenv run python reindex.py --types posts replies --include-active
+  pipenv run python reindex.py --migrate --types posts replies --include-active
 
-  # Start fresh, discarding any saved resume state
-  pipenv run python reindex.py --types posts --reset
+  # Discard resume state and start migration fresh
+  pipenv run python reindex.py --migrate --types posts --reset
 """,
     )
+
+    # ── Operations (at least one required) ───────────────────────────────────
+    parser.add_argument(
+        "--migrate",
+        action="store_true",
+        help=(
+            "Reindex each source index into a new destination with the updated shard count, "
+            "then atomically swap all aliases and delete the source."
+        ),
+    )
+    parser.add_argument(
+        "--force-merge",
+        action="store_true",
+        help=(
+            "Force-merge indices to 1 segment to reduce per-shard term-seek overhead. "
+            "When used alone: submits all force-merges async then polls with progress. "
+            "When combined with --migrate: fires force-merge after each alias swap "
+            "without waiting (runs concurrently with the next index migration). "
+            "Heavy I/O — run off-peak."
+        ),
+    )
+
+    # ── Index targeting (mutually exclusive, required) ────────────────────────
     index_group = parser.add_mutually_exclusive_group(required=True)
     index_group.add_argument(
         "--types",
@@ -842,7 +980,7 @@ examples:
         choices=list(INDEX_TYPES),
         metavar="TYPE",
         help=(
-            f"Discover and migrate all indices of the given type(s). "
+            f"Discover all indices of the given type(s). "
             f"Choices: {', '.join(INDEX_TYPES)}. "
             f"Mutually exclusive with --indices."
         ),
@@ -852,54 +990,50 @@ examples:
         nargs="+",
         metavar="INDEX",
         help=(
-            "Migrate specific named indices (e.g. posts-2026-w26) instead of "
-            "discovering by type. Bypasses the active-index guard, so you can "
-            "reindex a formerly-active index after the write period rolls over "
-            "without using --include-active. Mutually exclusive with --types."
+            "Target specific named indices (e.g. posts-2026-w26) instead of discovering "
+            "by type. For --migrate: bypasses the active-index guard so you can reindex "
+            "a formerly-active index after rollover without --include-active. "
+            "Mutually exclusive with --types."
         ),
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print what would happen without making any changes. State is not saved.",
-    )
+
+    # ── Migration options ─────────────────────────────────────────────────────
     parser.add_argument(
         "--include-active",
         action="store_true",
         help=(
-            "Also migrate the index currently receiving live writes. "
-            "Prompts for confirmation before proceeding — only safe when all ingest "
-            "services are stopped. Prefer --indices after the write period rolls over."
+            "(--migrate only) Also migrate the index currently receiving live writes. "
+            "Prompts for confirmation — only safe when all ingest services are stopped. "
+            "Prefer --indices after the write period rolls over."
         ),
     )
     parser.add_argument(
         "--commit",
         metavar="HASH",
-        help="Override the git commit hash used as the destination index suffix.",
-    )
-    parser.add_argument(
-        "--force-merge",
-        action="store_true",
-        help=(
-            "After each reindex completes, force-merge the destination index to 1 segment "
-            "before swapping aliases. Reduces per-shard term-seek cost immediately rather "
-            "than waiting for the ILM warm phase. Heavy I/O — run off-peak."
-        ),
+        help="(--migrate only) Override the git commit hash used as the destination index suffix.",
     )
     parser.add_argument(
         "--reset",
         action="store_true",
-        help="Discard any saved state and start the migration from scratch.",
+        help="(--migrate only) Discard any saved resume state and start fresh.",
     )
+
+    # ── General ───────────────────────────────────────────────────────────────
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would happen without making any changes. State is not saved.",
+    )
+
     args = parser.parse_args()
     try:
         exit_code = asyncio.run(_run(args))
     except KeyboardInterrupt:
         console.print()
         _warn(
-            "Interrupted — any in-flight Elasticsearch reindex task keeps running "
-            "server-side. Re-run with the same --types to resume; the script will "
-            "re-attach to the running task."
+            "Interrupted — any in-flight Elasticsearch tasks keep running server-side. "
+            "Re-run with the same flags to resume migration; the script will re-attach "
+            "to running reindex tasks. Use GET /_tasks to monitor force-merge tasks."
         )
         sys.exit(130)
     sys.exit(exit_code)

--- a/tools/reindex_state.py
+++ b/tools/reindex_state.py
@@ -1,0 +1,99 @@
+"""Persistent run-state for reindex.py.
+
+State is written to tools/state/reindex-state.json after every status
+transition so migrations can be resumed after interruption.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+STATE_DIR  = Path(__file__).parent / "state"
+STATE_FILE = STATE_DIR / "reindex-state.json"
+
+# Per-index status values — drive the migration state machine.
+PENDING      = "pending"
+REINDEXING   = "reindexing"
+SWAP_PENDING = "swap_pending"
+DONE         = "done"
+SKIPPED      = "skipped"
+FAILED       = "failed"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class IndexState:
+    status: str    # PENDING | REINDEXING | SWAP_PENDING | DONE | SKIPPED | FAILED
+    src: str
+    dst: str
+    task_id: str | None = None
+    error: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+
+
+@dataclass
+class RunState:
+    commit: str
+    types: list[str]
+    created_at: str
+    indices: dict[str, IndexState] = field(default_factory=dict)
+    explicit_indices: list[str] = field(default_factory=list)
+
+    @classmethod
+    def create(
+        cls,
+        commit: str,
+        types: list[str],
+        explicit_indices: list[str] | None = None,
+    ) -> RunState:
+        return cls(
+            commit=commit,
+            types=sorted(types),
+            explicit_indices=sorted(explicit_indices or []),
+            created_at=_now(),
+        )
+
+    @classmethod
+    def load(cls) -> RunState | None:
+        if not STATE_FILE.exists():
+            return None
+        try:
+            data = json.loads(STATE_FILE.read_text())
+            return cls(
+                commit=data["commit"],
+                types=data["types"],
+                explicit_indices=data.get("explicit_indices", []),
+                created_at=data["created_at"],
+                indices={
+                    src: IndexState(**vals)
+                    for src, vals in data.get("indices", {}).items()
+                },
+            )
+        except Exception:
+            return None
+
+    def save(self) -> None:
+        STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "commit": self.commit,
+            "types": self.types,
+            "explicit_indices": self.explicit_indices,
+            "created_at": self.created_at,
+            "indices": {src: dataclasses.asdict(s) for src, s in self.indices.items()},
+        }
+        STATE_FILE.write_text(json.dumps(data, indent=2))
+
+    def update(self, src: str, **kwargs: Any) -> None:
+        """Update fields on one index entry and persist immediately."""
+        for k, v in kwargs.items():
+            setattr(self.indices[src], k, v)
+        self.save()

--- a/tools/test_reindex.py
+++ b/tools/test_reindex.py
@@ -268,51 +268,80 @@ async def test_poll_task_eviction_partial_returns_failed(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _force_merge_index
+# _start_force_merge_task
 # ---------------------------------------------------------------------------
 
-async def test_force_merge_index_calls_forcemerge():
+async def test_start_force_merge_task_returns_task_id():
     es = _es()
-    es.indices.forcemerge.return_value = {"_shards": {"successful": 3}}
-    await reindex._force_merge_index(es, "posts-2026-w25-abc1234")
+    es.indices.forcemerge.return_value = {"task": "node1:42"}
+    result = await reindex._start_force_merge_task(es, "posts-2026-w25-abc1234")
+    assert result == "node1:42"
     es.indices.forcemerge.assert_awaited_once_with(
-        index="posts-2026-w25-abc1234", max_num_segments=1, wait_for_completion=True
+        index="posts-2026-w25-abc1234", max_num_segments=1, wait_for_completion=False
     )
 
 
-async def test_force_merge_index_swallows_errors():
+async def test_start_force_merge_task_returns_none_on_error():
     es = _es()
     es.indices.forcemerge.side_effect = Exception("timeout")
-    # Should not raise
-    await reindex._force_merge_index(es, "posts-2026-w25-abc1234")
+    result = await reindex._start_force_merge_task(es, "posts-2026-w25-abc1234")
+    assert result is None
 
 
 # ---------------------------------------------------------------------------
-# _process_index — force_merge flag
+# _poll_all_force_merges
 # ---------------------------------------------------------------------------
 
-async def test_process_index_calls_force_merge_when_flagged(monkeypatch):
+async def test_poll_all_force_merges_completes_all(monkeypatch):
+    es = _es()
+    monkeypatch.setattr(reindex.asyncio, "sleep", AsyncMock())
+    es.tasks.get.side_effect = [
+        # First poll: idx-a running, idx-b done
+        {"completed": False, "task": {"running_time_in_nanos": 1_000_000_000}},
+        {"completed": True, "task": {"running_time_in_nanos": 2_000_000_000},
+         "response": {"_shards": {"failures": []}}},
+        # Second poll: idx-a done
+        {"completed": True, "task": {"running_time_in_nanos": 3_000_000_000},
+         "response": {"_shards": {"failures": []}}},
+    ]
+    await reindex._poll_all_force_merges(es, {"idx-a": "t1", "idx-b": "t2"})
+    assert es.tasks.get.await_count == 3
+
+
+async def test_poll_all_force_merges_eviction_proceeds(monkeypatch):
+    es = _es()
+    monkeypatch.setattr(reindex.asyncio, "sleep", AsyncMock())
+    es.tasks.get.side_effect = _nf()
+    # Should complete without error even if task is evicted
+    await reindex._poll_all_force_merges(es, {"idx-a": "t1"})
+
+
+async def test_poll_all_force_merges_shard_failures_nonfatal(monkeypatch):
+    es = _es()
+    monkeypatch.setattr(reindex.asyncio, "sleep", AsyncMock())
+    es.tasks.get.return_value = {
+        "completed": True,
+        "task": {"running_time_in_nanos": 1_000_000_000},
+        "response": {"_shards": {"failures": [{"shard": 0, "reason": "disk full"}]}},
+    }
+    # Should not raise even with shard failures
+    await reindex._poll_all_force_merges(es, {"idx-a": "t1"})
+
+
+# ---------------------------------------------------------------------------
+# _process_index — no force_merge parameter (FM handled at caller level)
+# ---------------------------------------------------------------------------
+
+async def test_process_index_completes_reindex_and_swap(monkeypatch):
     es = _es()
     st = _state("s", "d", status=SWAP_PENDING)
     monkeypatch.setattr(reindex, "_ensure_reindex", AsyncMock(return_value=SWAP_PENDING))
-    fm = AsyncMock()
-    monkeypatch.setattr(reindex, "_force_merge_index", fm)
-    monkeypatch.setattr(reindex, "_do_swap", AsyncMock(return_value=DONE))
+    swap = AsyncMock(return_value=DONE)
+    monkeypatch.setattr(reindex, "_do_swap", swap)
 
-    await reindex._process_index(es, st, "s", "abc1234", dry_run=False, force_merge=True)
-    fm.assert_awaited_once_with(es, "d")
-
-
-async def test_process_index_skips_force_merge_when_not_flagged(monkeypatch):
-    es = _es()
-    st = _state("s", "d", status=SWAP_PENDING)
-    monkeypatch.setattr(reindex, "_ensure_reindex", AsyncMock(return_value=SWAP_PENDING))
-    fm = AsyncMock()
-    monkeypatch.setattr(reindex, "_force_merge_index", fm)
-    monkeypatch.setattr(reindex, "_do_swap", AsyncMock(return_value=DONE))
-
-    await reindex._process_index(es, st, "s", "abc1234", dry_run=False, force_merge=False)
-    fm.assert_not_awaited()
+    await reindex._process_index(es, st, "s", "abc1234", dry_run=False)
+    swap.assert_awaited_once()
+    assert st.indices["s"].status == DONE
 
 
 # ---------------------------------------------------------------------------

--- a/tools/test_reindex.py
+++ b/tools/test_reindex.py
@@ -23,6 +23,7 @@ from reindex import (  # noqa: E402
     SWAP_PENDING,
     IndexState,
     RunState,
+    _confirm_include_active,
 )
 
 
@@ -312,3 +313,44 @@ async def test_process_index_skips_force_merge_when_not_flagged(monkeypatch):
 
     await reindex._process_index(es, st, "s", "abc1234", dry_run=False, force_merge=False)
     fm.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _confirm_include_active
+# ---------------------------------------------------------------------------
+
+def test_confirm_include_active_yes(monkeypatch):
+    monkeypatch.setitem(__builtins__ if isinstance(__builtins__, dict) else vars(__builtins__), "input", lambda _: "y")
+    assert _confirm_include_active("posts-2026-w26", "posts") is True
+
+
+def test_confirm_include_active_no(monkeypatch):
+    monkeypatch.setitem(__builtins__ if isinstance(__builtins__, dict) else vars(__builtins__), "input", lambda _: "n")
+    assert _confirm_include_active("posts-2026-w26", "posts") is False
+
+
+def test_confirm_include_active_empty_defaults_no(monkeypatch):
+    monkeypatch.setitem(__builtins__ if isinstance(__builtins__, dict) else vars(__builtins__), "input", lambda _: "")
+    assert _confirm_include_active("posts-2026-w26", "posts") is False
+
+
+def test_confirm_include_active_eof_returns_false(monkeypatch):
+    def _raise(_):
+        raise EOFError
+    monkeypatch.setitem(__builtins__ if isinstance(__builtins__, dict) else vars(__builtins__), "input", _raise)
+    assert _confirm_include_active("posts-2026-w26", "posts") is False
+
+
+# ---------------------------------------------------------------------------
+# RunState — explicit_indices field
+# ---------------------------------------------------------------------------
+
+def test_runstate_create_stores_explicit_indices():
+    st = RunState.create("abc1234", [], explicit_indices=["posts-2026-w25", "replies-2026-w25"])
+    assert sorted(st.explicit_indices) == ["posts-2026-w25", "replies-2026-w25"]
+    assert st.types == []
+
+
+def test_runstate_create_without_explicit_indices():
+    st = RunState.create("abc1234", ["posts", "replies"])
+    assert st.explicit_indices == []

--- a/tools/test_reindex.py
+++ b/tools/test_reindex.py
@@ -264,3 +264,51 @@ async def test_poll_task_eviction_partial_returns_failed(monkeypatch):
     es.tasks.get.side_effect = _nf()
 
     assert await reindex._poll_task(es, st, "s") == FAILED
+
+
+# ---------------------------------------------------------------------------
+# _force_merge_index
+# ---------------------------------------------------------------------------
+
+async def test_force_merge_index_calls_forcemerge():
+    es = _es()
+    es.indices.forcemerge.return_value = {"_shards": {"successful": 3}}
+    await reindex._force_merge_index(es, "posts-2026-w25-abc1234")
+    es.indices.forcemerge.assert_awaited_once_with(
+        index="posts-2026-w25-abc1234", max_num_segments=1, wait_for_completion=True
+    )
+
+
+async def test_force_merge_index_swallows_errors():
+    es = _es()
+    es.indices.forcemerge.side_effect = Exception("timeout")
+    # Should not raise
+    await reindex._force_merge_index(es, "posts-2026-w25-abc1234")
+
+
+# ---------------------------------------------------------------------------
+# _process_index — force_merge flag
+# ---------------------------------------------------------------------------
+
+async def test_process_index_calls_force_merge_when_flagged(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=SWAP_PENDING)
+    monkeypatch.setattr(reindex, "_ensure_reindex", AsyncMock(return_value=SWAP_PENDING))
+    fm = AsyncMock()
+    monkeypatch.setattr(reindex, "_force_merge_index", fm)
+    monkeypatch.setattr(reindex, "_do_swap", AsyncMock(return_value=DONE))
+
+    await reindex._process_index(es, st, "s", "abc1234", dry_run=False, force_merge=True)
+    fm.assert_awaited_once_with(es, "d")
+
+
+async def test_process_index_skips_force_merge_when_not_flagged(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=SWAP_PENDING)
+    monkeypatch.setattr(reindex, "_ensure_reindex", AsyncMock(return_value=SWAP_PENDING))
+    fm = AsyncMock()
+    monkeypatch.setattr(reindex, "_force_merge_index", fm)
+    monkeypatch.setattr(reindex, "_do_swap", AsyncMock(return_value=DONE))
+
+    await reindex._process_index(es, st, "s", "abc1234", dry_run=False, force_merge=False)
+    fm.assert_not_awaited()


### PR DESCRIPTION
Part of #395

Posts and replies indices are undershareded relative to their current size (~50 GB/shard on posts-w25 at 7 shards). This PR reshard to 3 shards and adds tooling to migrate existing indices and reduce Lucene segment overhead via force-merge.

# This PR

- Reduce `posts_index_shards` and `replies_index_shards` from 7 → 3 in prod kustomization
- Add ILM warm-phase force-merge policy (`ilm_forcemerge_age`) for posts and replies in all environments (prod: 8d, stage: 30m, local: 5m); likes and tombstones keep delete-only policy
- Add `--migrate` flag to `reindex.py` (required for migration operations)
- Add `--force-merge` flag: standalone mode submits async FM tasks and polls with progress; combined with `--migrate` fires FM after each alias swap (fire-and-forget, concurrent with next index)
- Add `--indices` flag to target specific indices by name, bypassing the active-index guard (enables safe two-pass migration: historical first, then formerly-active after rollover)
- Add `--include-active` confirmation dialog with data-loss warning (stops ingest before using)
- Split state management into `tools/reindex_state.py` (`IndexState`, `RunState`, status constants); `reindex.py` imports and re-exports them for backward-compatible tests
- Refactor `reindex.py`: lift `_migrate_one` nested closure to module-level `_migrate_and_maybe_fm`; extract `_classify_for_migration`, `_resolve_active_write_index`, `_load_or_create_state`, `_run_migrate`, `_run_force_merge`; `_run` is now a thin dispatcher (~30 lines)
- Update README "Index Schema Migrations" section: document two-pass migration workflow, `--force-merge`, `--indices`, combined mode, resume behavior

# Testing

- 29 unit tests passing (`pytest test_reindex.py -v`) covering state machine, resilience paths, force-merge polling, `_confirm_include_active`, and `RunState` persistence
- Tested dry-run against stage: `pipenv run python reindex.py --migrate --types posts replies --dry-run`