### PR TITLE
Allow migrations for previously migrated indices

### DIFF
--- a/tools/reindex.py
+++ b/tools/reindex.py
@@ -86,6 +86,18 @@ POLL_INTERVAL_SECS = 10
 _MIGRATED_RE = re.compile(r"-[0-9a-f]{7}$")
 
 
+def _compute_dst(idx: str, commit: str) -> str:
+    """Return the destination index name for idx at commit.
+
+    If idx already carries a 7-char hex suffix from a previous migration, that
+    suffix is replaced with commit rather than appended, keeping names flat.
+    """
+    if _MIGRATED_RE.search(idx):
+        base = idx[: idx.rfind("-")]
+        return f"{base}-{commit}"
+    return f"{idx}-{commit}"
+
+
 # ---------------------------------------------------------------------------
 # Output helpers
 # ---------------------------------------------------------------------------
@@ -431,7 +443,8 @@ async def _process_index(
 ) -> None:
     """Drive one index through its full migration state machine (reindex → swap)."""
     if dry_run:
-        _info(f"[dim][dry-run][/dim] Would reindex {src} → {src}-{commit}, swap aliases, delete src.")
+        dst = _compute_dst(src, commit)
+        _info(f"[dim][dry-run][/dim] Would reindex {src} → {dst}, swap aliases, delete src.")
         return
 
     assert state is not None
@@ -630,16 +643,19 @@ def _classify_for_migration(
         return True
 
     if _MIGRATED_RE.search(idx):
-        if state is not None:
-            state.indices[idx] = IndexState(
-                status=SKIPPED, src=idx, dst=idx, error="already migrated",
-            )
-            state.save()
-        _info(f"Skipping already-migrated index: {idx}")
-        return True
+        if idx.endswith(f"-{commit}"):
+            if state is not None:
+                state.indices[idx] = IndexState(
+                    status=SKIPPED, src=idx, dst=idx, error="already migrated",
+                )
+                state.save()
+            _info(f"Skipping already-migrated index: {idx}")
+            return True
+        # Migrated to a different (old) commit — fall through to re-migrate.
 
+    dst = _compute_dst(idx, commit)
     if state is not None:
-        state.indices[idx] = IndexState(status=PENDING, src=idx, dst=f"{idx}-{commit}")
+        state.indices[idx] = IndexState(status=PENDING, src=idx, dst=dst)
         state.save()
 
     return False

--- a/tools/test_reindex.py
+++ b/tools/test_reindex.py
@@ -383,3 +383,54 @@ def test_runstate_create_stores_explicit_indices():
 def test_runstate_create_without_explicit_indices():
     st = RunState.create("abc1234", ["posts", "replies"])
     assert st.explicit_indices == []
+
+
+# ---------------------------------------------------------------------------
+# _compute_dst
+# ---------------------------------------------------------------------------
+
+def test_compute_dst_plain_index():
+    assert reindex._compute_dst("posts-2026-w18", "803b0a1") == "posts-2026-w18-803b0a1"
+
+
+def test_compute_dst_already_has_old_hash():
+    """An index migrated to a previous SHA gets its old suffix replaced."""
+    assert reindex._compute_dst("posts-2026-w18-35592b1", "803b0a1") == "posts-2026-w18-803b0a1"
+
+
+def test_compute_dst_already_at_current_hash():
+    """An index already at the current SHA is idempotent (replaces with same suffix)."""
+    assert reindex._compute_dst("posts-2026-w18-803b0a1", "803b0a1") == "posts-2026-w18-803b0a1"
+
+
+# ---------------------------------------------------------------------------
+# _classify_for_migration — already-migrated detection
+# ---------------------------------------------------------------------------
+
+def test_classify_skips_index_at_current_commit():
+    """Index already at target SHA is skipped."""
+    skipped = reindex._classify_for_migration("posts-2026-w18-803b0a1", None, None, "803b0a1")
+    assert skipped is True
+
+
+def test_classify_does_not_skip_index_at_old_commit():
+    """Index migrated to a different (old) SHA must be re-migrated."""
+    skipped = reindex._classify_for_migration("posts-2026-w18-35592b1", None, None, "803b0a1")
+    assert skipped is False
+
+
+def test_classify_old_sha_sets_correct_dst():
+    """Dst for an old-SHA index strips the old hash rather than appending."""
+    st = RunState.create("803b0a1", ["posts"])
+    st.save = lambda: None
+    reindex._classify_for_migration("posts-2026-w18-35592b1", None, st, "803b0a1")
+    assert st.indices["posts-2026-w18-35592b1"].dst == "posts-2026-w18-803b0a1"
+
+
+def test_classify_plain_index_pending_with_correct_dst():
+    """Plain (never-migrated) index is registered as PENDING with correct dst."""
+    st = RunState.create("803b0a1", ["posts"])
+    st.save = lambda: None
+    skipped = reindex._classify_for_migration("posts-2026-w18", None, st, "803b0a1")
+    assert skipped is False
+    assert st.indices["posts-2026-w18"].dst == "posts-2026-w18-803b0a1"


### PR DESCRIPTION
Previously migration script would skip indices that had been the result of a previous migration. This update fixes this to check the current SHA and proceed with migration if different than the previous migration result SHA.