### PR TITLE
fix: add service instance ID to OTel resource

### DIFF
--- a/ingest/internal/common/otel_metrics.go
+++ b/ingest/internal/common/otel_metrics.go
@@ -2,19 +2,19 @@ package common
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
-	"fmt"
 	gcpmetric "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
-
-	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 )
 
 // OTelMetricCollector exports metrics via OpenTelemetry to GCP Cloud Monitoring or stdout.
@@ -51,12 +51,21 @@ func NewOTelMetricCollector(serviceName, env, projectID, region string, exportIn
 		}
 	}
 
+	// Use Cloud Run instance ID (or hostname as fallback) as node_id so each
+	// instance gets its own GCP metric series — prevents "Points must be written
+	// in order" errors when multiple instances share the same cumulative series.
+	instanceID := os.Getenv("INSTANCE_ID")
+	if instanceID == "" {
+		instanceID, _ = os.Hostname()
+	}
+
 	res, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(
 			semconv.ServiceName(serviceName),
 			semconv.ServiceNamespace(env),
 			semconv.CloudRegion(region),
+			semconv.ServiceInstanceID(instanceID),
 		),
 	)
 	if err != nil {

--- a/ingest/internal/common/otel_metrics.go
+++ b/ingest/internal/common/otel_metrics.go
@@ -2,8 +2,8 @@ package common
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -51,13 +51,12 @@ func NewOTelMetricCollector(serviceName, env, projectID, region string, exportIn
 		}
 	}
 
-	// Use Cloud Run instance ID (or hostname as fallback) as node_id so each
-	// instance gets its own GCP metric series — prevents "Points must be written
-	// in order" errors when multiple instances share the same cumulative series.
-	instanceID := os.Getenv("INSTANCE_ID")
-	if instanceID == "" {
-		instanceID, _ = os.Hostname()
-	}
+	// Generate a random instance ID per process so each Cloud Run instance gets
+	// its own GCP metric series — prevents "Points must be written in order"
+	// errors when multiple instances share the same cumulative series.
+	// Cloud Run does not expose a per-instance env var; hostname returns
+	// "localhost" for all instances, so we generate a UUID at startup instead.
+	instanceID := generateInstanceID()
 
 	res, err := resource.New(
 		context.Background(),
@@ -218,4 +217,12 @@ func (c *OTelMetricCollector) getOrCreateGauge(name string) metric.Float64Gauge 
 	g, _ = c.meter.Float64Gauge(name)
 	c.gauges[name] = g
 	return g
+}
+
+func generateInstanceID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "unknown"
+	}
+	return fmt.Sprintf("%x", b)
 }


### PR DESCRIPTION
## Problem

Since June 24, all megastream ingest metrics stopped being reported to GCP Cloud Monitoring. The following error appeared repeatedly in Cloud Logging:

```
rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written:
write for resource failed: Points must be written in order.
One or more of the points specified had an older start time than the most recent point.
```

**Root cause:** The `generic_node` resource used by the OTel GCP exporter had an empty `node_id`, meaning every Cloud Run instance wrote to the same GCP metric series. When a new instance started alongside the existing one, GCP rejected this as an out-of-order write, and continued rejecting all subsequent points from the new instance.

Timeline reconstructed from Cloud Logging:

| Instance | Started (UTC) | Ended (UTC) | Note |
|---|---|---|---|
| `...47fc1917` | 18:16:46 | 19:57:14 | Original instance; owned the metric series |
| `...4700dee8` | 19:56:51 | still running | Replacement; all metric writes rejected |
| `...4732d349` | 19:57:15 | 19:57:34 | Short-lived; exited via newer-instance detection |

Both replacement instances had an earlier start time than the last point written by `...47fc1917`, causing GCP to reject every metric write from that point onward.

## Fix

Set `service.instance.id` on the OTel resource by assigning random hex generated by`generateInstanceID`. This maps to `node_id` in the `generic_node` resource type.

This is the standard practice recommended by the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/resource/#service).

Close #398 