### PR TITLE
Reduce prod likes shard count 7 to 2; add ILM warm forcemerge phase for likes

### DIFF
--- a/index/deploy/k8s/base/bootstrap-job.yaml
+++ b/index/deploy/k8s/base/bootstrap-job.yaml
@@ -66,7 +66,7 @@ spec:
           curl -k --fail-with-body -X PUT "https://greenearth-es-http:9200/_ilm/policy/likes_ilm_policy" \
             -u "es-service-user:$ES_SERVICE_PASSWORD" \
             -H "Content-Type: application/json" \
-            -d "$ILM_DELETE_POLICY"
+            -d "$ILM_FORCEMERGE_POLICY"
 
           curl -k --fail-with-body -X PUT "https://greenearth-es-http:9200/_ilm/policy/tombstones_ilm_policy" \
             -u "es-service-user:$ES_SERVICE_PASSWORD" \

--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -124,7 +124,7 @@ configMapGenerator:
     literals:
       - posts_index_shards=3
       - posts_index_replicas=1
-      - likes_index_shards=7
+      - likes_index_shards=2
       - likes_index_replicas=1
       - tombstones_index_shards=3
       - tombstones_index_replicas=1


### PR DESCRIPTION
Part of greenearth-social/api#312

The `likes` shard count is a vestige of a single-index layout; since likes were split into weekly indices it has been over-provisioned. Sizing investigation and measurements are in [this comment](https://github.com/greenearth-social/api/issues/312#issuecomment-5079293479). `network_likes` is currently a production bottleneck, so this reshards existing indices rather than waiting for natural rollover.

# This PR

- Reduce `likes_index_shards` from 7 → 2 in prod kustomization. Measured weekly volume is ~25.5 GB / ~135M docs, so 7 shards gives 3.6 GB/shard — ~3× under Elastic's 10 GB floor. 2 shards lands at 12.8 GB / 68M docs per shard, both comfortably in band with ~3× growth headroom. Cuts `likes` from 112 of the cluster's 548 shards (20.4%) down to 32.
- Switch `likes_ilm_policy` from `ILM_DELETE_POLICY` to `ILM_FORCEMERGE_POLICY` in the bootstrap job, so likes pick up the same 8d warm-phase force-merge that posts/replies already have. `likes-2026-w29` currently carries 23–31 segments per shard vs exactly 1 on force-merged `posts-2026-w27`/`replies-2026-w27`; a `terms` query seeks the term dictionary once per segment per shard, so this is the dominant cost on the routed single-user path that resharding alone cannot improve.

No changes to stage (`likes_index_shards` already 2), local (already 1), or the tombstones policy. No tooling changes — `reindex.py` already registers the `likes` type and supports `--force-merge`.

# Testing

- `pytest test_reindex.py` in `tools/`: 36 passed
- Rendered prod overlay and confirmed `likes_index_shards: "2"`: `kubectl kustomize index/deploy/k8s/environments/prod`
- Verified `disableNameSuffixHash: true` on the generator, so the bootstrap job's `configMapKeyRef: ilm-settings` still resolves (the job is applied directly by `deploy.sh`, not through kustomize)
- Validated the interpolated `ILM_FORCEMERGE_POLICY` JSON parses and yields `warm.min_age=8d` / `forcemerge.max_num_segments=1` / `delete.min_age=60d`
- YAML parse check on both modified files
- Baseline measurements taken read-only against prod ES (`_cat`, `_count`, `_ilm`, and representative `network_likes`-shaped searches)

# Post-migration index naming — audit of SHA-suffix handling

Migration renames indices to `likes-<period>-<sha>`. Every mechanism that resolves likes indices by name was checked:

| Mechanism | Pattern | Status |
|---|---|---|
| SLM snapshot policy (`elasticsearch-snapshot-setup-job.yaml:74`) | `likes*` | ✅ wildcard already matches suffixed names |
| `restore.sh:140` `SNAPSHOT_INDICES` | `likes*` | ✅ same |
| ILM policy attachment (`likes_ilm_template`) | `likes-*` | ✅ suffixed indices match at creation; verified on prod that `posts_ilm_policy.in_use_by` includes the `-6c6ceae` indices |
| `update-recent-alias-cronjob` | `posts-*` only | ✅ N/A — no `likes_recent` alias exists, so the 15e2768 wildcard fix has no likes analogue to port |
| `elasticsearch_expiry` | none | ✅ likes are ILM-managed, no index-name logic |

**The one gap that was never fixed is the ILM clock reset** (only a warning was added, 4039a88). It is what caused #411: 1.64 TB of stale `posts-*-6c6ceae` indices had to be manually deleted on 2026-07-23. It applies identically to likes, and is handled below by scoping which weeks get migrated.

# Deploy notes

**1. Pause ILM during the migration** to prevent force merging segments before the shards are re-indexed. 

```bash
gcloud container clusters get-credentials greenearth-stage-cluster \
  --region=us-east1 --project=greenearth-471522
kubectl port-forward service/greenearth-es-http 9200:9200 -n greenearth-stage &
export GE_ELASTICSEARCH_PASSWORD=$(kubectl get secret -n greenearth-stage greenearth-es-elastic-user -o jsonpath='{.data.elastic}' | base64 -d)
AUTH="elastic:$GE_ELASTICSEARCH_PASSWORD"
ES=https://localhost:9200
curl -k -u "$AUTH" -XPOST "$ES/_ilm/stop"
curl -k -u "$AUTH" "$ES/_ilm/status"    # poll until {"operation_mode":"STOPPED"}

# ... run migration ...

curl -k -u "$AUTH" -XPOST "$ES/_ilm/start"
curl -k -u "$AUTH" "$ES/_ilm/status"    # expect {"operation_mode":"RUNNING"}
```

**2. Run migration, skipping the near-expiry weeks.** Reindexing resets each index's ILM creation date, so a week that was about to be deleted instead survives another 60 days. 

Suggested scope:

```bash
cd tools
export GE_ELASTICSEARCH_TLS_SKIP_VERIFY=true
pipenv run python reindex.py --migrate --force-merge --indices \
  likes-2026-w25 likes-2026-w26 likes-2026-w27 likes-2026-w28 likes-2026-w29 likes-2026-w30 --dry-run
# drop --dry-run to execute
# after w32 opens, catch the formerly-active index
pipenv run python reindex.py --migrate --force-merge --indices likes-2026-w31
```

**3. Re-enable ILM** (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
