### PR TITLE
Increase prod ES data node memory 32Gi to 40Gi

### DIFF
--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -60,10 +60,10 @@ patches:
               - name: elasticsearch
                 resources:
                   requests:
-                    memory: 32Gi
+                    memory: 40Gi
                     cpu: "1250m"
                   limits:
-                    memory: 32Gi
+                    memory: 40Gi
                     cpu: "1250m"
                 env:
                 - name: ES_JAVA_OPTS


### PR DESCRIPTION
Part of greenearth-social/api#312

That issue traces the serving-path slowness to page-cache residency rather than query shape — identical queries run ~100× slower under load (a trivial likes lookup measured 27 ms replayed off-peak vs p50 2.5 s in the prod slow-query logs). greenearth-social/ingex#412 reduced the shard and segment count to cut per-shard overhead; this PR attacks the other side of the same problem by giving the data nodes more room to cache.

# This PR

- Increase prod ES **data node** memory from 32Gi → 40Gi (requests and limits), a 25% increase. Node count stays at 4, so cluster-wide data node memory goes 128Gi → 160Gi.
- **Deliberately leave `ES_JAVA_OPTS` at `-Xms16g -Xmx16g`.** Heap is not the constraint — measured heap on the four data nodes was 61% / 20% / 18% / 8%, while `ram.percent` sat at 84–100%. Holding heap flat means the entire increase lands in page cache: per-node cache headroom goes from ~16Gi to ~24Gi, a **50% increase** off a 25% RAM bump.

Master nodes are unchanged (6Gi, `-Xms3g -Xmx3g`, measured 59–62% RAM). They hold cluster state and are not implicated in the serving-path latency.

# Testing

- `kubectl kustomize index/deploy/k8s/environments/prod` renders the data nodeSet with `memory: 40Gi` on both requests and limits, and `ES_JAVA_OPTS` still `-Xms16g -Xmx16g`
- YAML parse check on the modified file
- Baseline `_cat/nodes` figures above captured read-only against prod ES

# Deploy

```bash
export GE_ELASTICSEARCH_SERVICE_USER_PWD='<from .env.prod>'
./index/deploy.sh prod --ctypes resource --dry-run
./index/deploy.sh prod --ctypes resource
```

`resource` is the change type that updates compute/storage; `schema` would not pick this up.

# Risks

**Rolling restart.** ECK rolls the data nodes one at a time to apply new pod resources. With 4 data nodes and 1 replica the cluster stays available, but each restarted node must recover shards and re-warm page cache, so expect degraded latency during the roll and for a while after. Run off-peak, and avoid overlapping with any in-flight force-merge from #412.

**GKE Autopilot resource ratios — please verify before merging.** The cluster is Autopilot (`gk3-` node prefix). The current data node request is 32Gi against 1250m CPU, a 25.6:1 memory:CPU ratio; this raises it to 32:1. Autopilot's general-purpose compute class constrains memory:CPU to roughly 6.5:1 and will bump CPU to satisfy it, which would carry a significant cost increase. The existing config already exceeds that limit and runs fine, so something is already absorbing it (a non-default compute class, or silent adjustment) — but I could not confirm which, and the ratio is getting worse, not better. Worth a `--dry-run` plus a look at the actual scheduled pod spec before applying.

**Cost.** 32Gi extra memory across the cluster, plus any CPU Autopilot adds to satisfy the ratio above.

# Note on sizing rationale

25% is the increase that was asked for rather than one derived from a target working-set size. The honest sizing question is what fraction of the hot data needs to be resident, and that depends on how much #412's segment reduction shrinks the index-metadata footprint — worth re-measuring `ram.percent` and slow-query volume after both land, rather than assuming this is the final number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
