### PR TITLE
Bump prod ES data node memory to 48Gi (step 0 of memory/RAM plan)

### DIFF
--- a/index/deploy/k8s/environments/prod/kustomization.yaml
+++ b/index/deploy/k8s/environments/prod/kustomization.yaml
@@ -60,14 +60,14 @@ patches:
               - name: elasticsearch
                 resources:
                   requests:
-                    memory: 32Gi
-                    cpu: "1250m"
+                    memory: 48Gi
+                    cpu: "7385m"
                   limits:
-                    memory: 32Gi
-                    cpu: "1250m"
+                    memory: 48Gi
+                    cpu: "7385m"
                 env:
                 - name: ES_JAVA_OPTS
-                  value: "-Xms16g -Xmx16g"
+                  value: "-Xms8g -Xmx8g"
           volumeClaimTemplates:
           - metadata:
               name: elasticsearch-data


### PR DESCRIPTION
Part of #312

This PR implements step 0 of the plan in the most recent comment on greenearth-social/api#312: a memory update to the prod ES data node kustomization to relieve page-cache pressure, ahead of the follow-up reader-side and ingest-side embedding source-exclusion changes described in the same comment.

> [!WARNING]
>  This is probably going to be a 50% increase in infra cost for us.

# This PR

- Bump prod ES data node pod resources from 32Gi/1250m to 48Gi/7385m CPU (autopilot general-purpose 1:6.5 CPU:mem ratio)
- Bump ES_JAVA_OPTS heap from -Xms16g -Xmx16g to -Xms8g -Xmx8g, leaving ~38G/node for OS page cache (vs ~14G today)

# Testing

- Rendered the patched kustomization with `kubectl kustomize index/deploy/k8s/environments/prod` and confirmed the data node pod template shows `memory: 48Gi`, `cpu: 7385m`, and `ES_JAVA_OPTS=-Xms8g -Xmx8g`
- Per the issue plan: after rollout, watch `jvm.gc` old-gen counts on data nodes; fall back to 10g heap if old-gen GCs appear