### PR TITLE
Exclude embeddings from _source in posts/replies (step 2 of api#312 memory plan)

### DIFF
--- a/index/deploy/k8s/base/templates/posts-ilm-index-template.yaml
+++ b/index/deploy/k8s/base/templates/posts-ilm-index-template.yaml
@@ -29,6 +29,9 @@ data:
           "_routing": {
             "required": true
           },
+          "_source": {
+            "excludes": ["embeddings"]
+          },
           "properties": {
             "at_uri": {
               "type": "keyword",

--- a/index/deploy/k8s/base/templates/posts-ilm-index-template.yaml
+++ b/index/deploy/k8s/base/templates/posts-ilm-index-template.yaml
@@ -61,8 +61,7 @@ data:
                 "all_MiniLM_L12_v2": {
                   "type": "dense_vector",
                   "dims": 384,
-                  "index": true,
-                  "similarity": "cosine"
+                  "index": false
                 },
                 "all_MiniLM_L6_v2": {
                   "type": "dense_vector",

--- a/index/deploy/k8s/base/templates/replies-ilm-index-template.yaml
+++ b/index/deploy/k8s/base/templates/replies-ilm-index-template.yaml
@@ -29,6 +29,9 @@ data:
           "_routing": {
             "required": true
           },
+          "_source": {
+            "excludes": ["embeddings"]
+          },
           "properties": {
             "at_uri": {
               "type": "keyword",

--- a/ingest/internal/common/elasticsearch.go
+++ b/ingest/internal/common/elasticsearch.go
@@ -938,10 +938,13 @@ type Hit struct {
 	Fields map[string]json.RawMessage `json:"fields,omitempty"`
 }
 
-// embeddingsFromHit returns hit's embeddings, preferring the "fields" retrieval
-// API over _source. Once an index's mapping excludes "embeddings" from
-// _source (api#312 step 2), Source.Embeddings is empty and the vectors are
-// only recoverable via "fields", which reads doc-value/indexed data directly.
+// embeddingsFromHit returns hit's embeddings, preferring the "docvalue_fields"
+// retrieval API over _source. Once an index's mapping excludes "embeddings"
+// from _source (api#312 step 2), Source.Embeddings is empty and the vectors
+// are only recoverable via "docvalue_fields", which reads doc values
+// directly and — unlike "fields" — never falls back to decompressing
+// _source (that fallback is what silently breaks "fields" once _source
+// excludes the field; see greenearth-social/api#325).
 func embeddingsFromHit(hit Hit) map[string][]float32 {
 	embeddings := make(map[string][]float32, len(hit.Fields))
 	for name, raw := range hit.Fields {
@@ -1085,9 +1088,11 @@ func FetchPosts(ctx context.Context, client *elasticsearch.Client, logger *Inges
 			map[string]interface{}{"indexed_at": "asc"},
 		},
 		"size": size,
-		// posts/replies templates exclude "embeddings" from _source (api#312 step 2),
-		// so request it via the fields API, which reads doc-value/indexed data directly.
-		"fields": []interface{}{"embeddings.*"},
+		// posts/replies templates exclude "embeddings" from _source (api#312 step 2).
+		// Use docvalue_fields, not fields: fields falls back to decompressing
+		// _source for dense_vector on this ES version, so it silently returns
+		// nothing once _source excludes the field (see api#325).
+		"docvalue_fields": []interface{}{"embeddings.*"},
 	}
 
 	if afterCreatedAt != "" && afterIndexedAt != "" {

--- a/ingest/internal/common/elasticsearch.go
+++ b/ingest/internal/common/elasticsearch.go
@@ -930,11 +930,35 @@ type TotalHits struct {
 
 // Hit represents a single search hit
 type Hit struct {
-	Index  string        `json:"_index"`
-	ID     string        `json:"_id"`
-	Score  float64       `json:"_score"`
-	Sort   []interface{} `json:"sort,omitempty"`
-	Source PostData      `json:"_source"`
+	Index  string                     `json:"_index"`
+	ID     string                     `json:"_id"`
+	Score  float64                    `json:"_score"`
+	Sort   []interface{}              `json:"sort,omitempty"`
+	Source PostData                   `json:"_source"`
+	Fields map[string]json.RawMessage `json:"fields,omitempty"`
+}
+
+// embeddingsFromHit returns hit's embeddings, preferring the "fields" retrieval
+// API over _source. Once an index's mapping excludes "embeddings" from
+// _source (api#312 step 2), Source.Embeddings is empty and the vectors are
+// only recoverable via "fields", which reads doc-value/indexed data directly.
+func embeddingsFromHit(hit Hit) map[string][]float32 {
+	embeddings := make(map[string][]float32, len(hit.Fields))
+	for name, raw := range hit.Fields {
+		modelName, ok := strings.CutPrefix(name, "embeddings.")
+		if !ok {
+			continue
+		}
+		var values [][]float32
+		if err := json.Unmarshal(raw, &values); err != nil || len(values) == 0 {
+			continue
+		}
+		embeddings[modelName] = values[0]
+	}
+	if len(embeddings) > 0 {
+		return embeddings
+	}
+	return hit.Source.Embeddings
 }
 
 // PostData represents the _source field of a search hit
@@ -1061,6 +1085,9 @@ func FetchPosts(ctx context.Context, client *elasticsearch.Client, logger *Inges
 			map[string]interface{}{"indexed_at": "asc"},
 		},
 		"size": size,
+		// posts/replies templates exclude "embeddings" from _source (api#312 step 2),
+		// so request it via the fields API, which reads doc-value/indexed data directly.
+		"fields": []interface{}{"embeddings.*"},
 	}
 
 	if afterCreatedAt != "" && afterIndexedAt != "" {
@@ -1183,7 +1210,6 @@ func FetchLikes(ctx context.Context, client *elasticsearch.Client, logger *Inges
 
 	return response, nil
 }
-
 
 // QueryPostsByAuthorDID retrieves all post at_uris for a given author_did using scroll API
 func QueryPostsByAuthorDID(ctx context.Context, client *elasticsearch.Client, index string, authorDID string, logger *IngestLogger) ([]string, error) {

--- a/ingest/internal/common/elasticsearch_fetch_posts_test.go
+++ b/ingest/internal/common/elasticsearch_fetch_posts_test.go
@@ -8,8 +8,10 @@ import (
 
 // TestEmbeddingsFromHit covers the fallback chain used because posts/replies
 // templates exclude "embeddings" from _source (greenearth-social/api#312 step 2):
-// once that happens, embeddings are only retrievable via the ES "fields" API,
-// not _source.
+// once that happens, embeddings are only retrievable via the ES "docvalue_fields"
+// API, not _source. Both "fields" and "docvalue_fields" populate the same
+// response key ("fields"), so these fixtures apply regardless of which request
+// param was used to ask for them.
 func TestEmbeddingsFromHit(t *testing.T) {
 	t.Run("prefers fields when present", func(t *testing.T) {
 		hit := Hit{
@@ -81,8 +83,10 @@ func TestEmbeddingsFromHit(t *testing.T) {
 }
 
 // TestFetchPosts_RequestsEmbeddingsViaFields verifies FetchPosts asks for
-// embeddings through the "fields" retrieval API (not just _source), so vectors
-// are still retrievable once _source excludes the "embeddings" object.
+// embeddings through the "docvalue_fields" retrieval API (not "fields" and
+// not just _source): "fields" falls back to decompressing _source for
+// dense_vector on this ES version, so it silently returns nothing once
+// _source excludes the field (see greenearth-social/api#325).
 func TestFetchPosts_RequestsEmbeddingsViaFields(t *testing.T) {
 	var capturedBody map[string]interface{}
 
@@ -101,11 +105,14 @@ func TestFetchPosts_RequestsEmbeddingsViaFields(t *testing.T) {
 		t.Fatalf("FetchPosts returned error: %v", err)
 	}
 
-	fields, ok := capturedBody["fields"].([]interface{})
+	fields, ok := capturedBody["docvalue_fields"].([]interface{})
 	if !ok || len(fields) == 0 {
-		t.Fatalf("expected query to request \"fields\", got: %v", capturedBody)
+		t.Fatalf("expected query to request \"docvalue_fields\", got: %v", capturedBody)
 	}
 	if fields[0] != "embeddings.*" {
-		t.Errorf("expected fields=[\"embeddings.*\"], got %v", fields)
+		t.Errorf("expected docvalue_fields=[\"embeddings.*\"], got %v", fields)
+	}
+	if _, ok := capturedBody["fields"]; ok {
+		t.Errorf("expected no \"fields\" param (silently returns nothing for dense_vector once _source excludes it), got: %v", capturedBody)
 	}
 }

--- a/ingest/internal/common/elasticsearch_fetch_posts_test.go
+++ b/ingest/internal/common/elasticsearch_fetch_posts_test.go
@@ -1,0 +1,111 @@
+package common
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestEmbeddingsFromHit covers the fallback chain used because posts/replies
+// templates exclude "embeddings" from _source (greenearth-social/api#312 step 2):
+// once that happens, embeddings are only retrievable via the ES "fields" API,
+// not _source.
+func TestEmbeddingsFromHit(t *testing.T) {
+	t.Run("prefers fields when present", func(t *testing.T) {
+		hit := Hit{
+			Source: PostData{Embeddings: nil},
+			Fields: map[string]json.RawMessage{
+				"embeddings.all_MiniLM_L12_v2": json.RawMessage(`[[0.1,0.2,0.3]]`),
+			},
+		}
+		got := embeddingsFromHit(hit)
+		want := []float32{0.1, 0.2, 0.3}
+		if len(got["all_MiniLM_L12_v2"]) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i, v := range want {
+			if got["all_MiniLM_L12_v2"][i] != v {
+				t.Errorf("index %d: got %v, want %v", i, got["all_MiniLM_L12_v2"][i], v)
+			}
+		}
+	})
+
+	t.Run("falls back to _source when no fields present", func(t *testing.T) {
+		hit := Hit{
+			Source: PostData{
+				Embeddings: map[string][]float32{"all_MiniLM_L12_v2": {1, 2, 3}},
+			},
+		}
+		got := embeddingsFromHit(hit)
+		if len(got["all_MiniLM_L12_v2"]) != 3 {
+			t.Fatalf("expected fallback to _source embeddings, got %v", got)
+		}
+	})
+
+	t.Run("falls back to _source when fields has no embeddings keys", func(t *testing.T) {
+		hit := Hit{
+			Source: PostData{
+				Embeddings: map[string][]float32{"all_MiniLM_L12_v2": {1, 2, 3}},
+			},
+			Fields: map[string]json.RawMessage{
+				"some_other_field": json.RawMessage(`["x"]`),
+			},
+		}
+		got := embeddingsFromHit(hit)
+		if len(got["all_MiniLM_L12_v2"]) != 3 {
+			t.Fatalf("expected fallback to _source embeddings, got %v", got)
+		}
+	})
+
+	t.Run("multiple embedding families from fields", func(t *testing.T) {
+		hit := Hit{
+			Fields: map[string]json.RawMessage{
+				"embeddings.all_MiniLM_L12_v2":          json.RawMessage(`[[0.1,0.2]]`),
+				"embeddings.google_embeddinggemma_300m": json.RawMessage(`[[0.9,0.8]]`),
+				"embeddings.ge_post_embedding":          json.RawMessage(`[[0.4,0.5]]`),
+			},
+		}
+		got := embeddingsFromHit(hit)
+		if len(got) != 3 {
+			t.Fatalf("expected 3 embedding families, got %v", got)
+		}
+	})
+
+	t.Run("no embeddings anywhere returns empty map", func(t *testing.T) {
+		hit := Hit{Source: PostData{}}
+		got := embeddingsFromHit(hit)
+		if len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+	})
+}
+
+// TestFetchPosts_RequestsEmbeddingsViaFields verifies FetchPosts asks for
+// embeddings through the "fields" retrieval API (not just _source), so vectors
+// are still retrievable once _source excludes the "embeddings" object.
+func TestFetchPosts_RequestsEmbeddingsViaFields(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	client, srv := newMockESClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":0,"hits":[]}}`))
+	}))
+	defer srv.Close()
+
+	logger := NewLogger(false)
+	_, err := FetchPosts(t.Context(), client, logger, "posts-2026-w30", "", "", "", "", 10)
+	if err != nil {
+		t.Fatalf("FetchPosts returned error: %v", err)
+	}
+
+	fields, ok := capturedBody["fields"].([]interface{})
+	if !ok || len(fields) == 0 {
+		t.Fatalf("expected query to request \"fields\", got: %v", capturedBody)
+	}
+	if fields[0] != "embeddings.*" {
+		t.Errorf("expected fields=[\"embeddings.*\"], got %v", fields)
+	}
+}

--- a/ingest/internal/common/megastream_message.go
+++ b/ingest/internal/common/megastream_message.go
@@ -280,13 +280,6 @@ func (m *megaStreamMessage) parseInferences(inferencesJSON string, logger *Inges
 				logger.Debug("Failed to decode L12 embedding for %s: %v", m.atURI, err)
 			}
 		}
-		if embL6, ok := textEmbeddings["all-MiniLM-L6-v2"].(string); ok {
-			if decoded, err := embeddings.Decode(embL6); err == nil {
-				m.embeddings["all_MiniLM_L6_v2"] = decoded
-			} else {
-				logger.Debug("Failed to decode L6 embedding for %s: %v", m.atURI, err)
-			}
-		}
 	}
 
 	video, ok := inferences["video"].(map[string]interface{})

--- a/ingest/internal/common/megastream_message_test.go
+++ b/ingest/internal/common/megastream_message_test.go
@@ -1,7 +1,10 @@
 package common
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/greenearth/ingest/internal/embeddings"
 )
 
 func TestIsAccountDeletion(t *testing.T) {
@@ -951,5 +954,49 @@ func TestMegaStreamMessage_CreatedAtNormalization(t *testing.T) {
 				t.Errorf("GetCreatedAt() = %q, expected %q", got, tt.expectedCreatedAt)
 			}
 		})
+	}
+}
+
+// TestMegaStreamMessage_EmbeddingsParsing covers issue greenearth-social/api#312 step 2:
+// all_MiniLM_L6_v2 is written by ingex but read by nothing in api, so parseInferences
+// must stop decoding and storing it, while still parsing the L12 and gemma embeddings.
+func TestMegaStreamMessage_EmbeddingsParsing(t *testing.T) {
+	logger := NewLogger(false)
+	rawPostJSON := `{
+		"message": {
+			"commit": {
+				"operation": "create",
+				"record": {
+					"text": "hello",
+					"createdAt": "2025-12-12T02:14:25.876Z"
+				}
+			}
+		}
+	}`
+
+	l12, err := embeddings.Encode([]float32{0.1, 0.2, 0.3})
+	if err != nil {
+		t.Fatalf("failed to encode L12 fixture: %v", err)
+	}
+	l6, err := embeddings.Encode([]float32{0.4, 0.5, 0.6})
+	if err != nil {
+		t.Fatalf("failed to encode L6 fixture: %v", err)
+	}
+
+	inferencesJSON := fmt.Sprintf(`{
+		"text_embeddings": {
+			"all-MiniLM-L12-v2": %q,
+			"all-MiniLM-L6-v2": %q
+		}
+	}`, l12, l6)
+
+	msg := NewMegaStreamMessage("at://test", "did:plc:test", rawPostJSON, inferencesJSON, logger)
+	got := msg.GetEmbeddings()
+
+	if _, ok := got["all_MiniLM_L6_v2"]; ok {
+		t.Errorf("expected all_MiniLM_L6_v2 to be dropped, but it was present: %v", got["all_MiniLM_L6_v2"])
+	}
+	if _, ok := got["all_MiniLM_L12_v2"]; !ok {
+		t.Errorf("expected all_MiniLM_L12_v2 to still be parsed, got %v", got)
 	}
 }

--- a/ingest/internal/common/parquet.go
+++ b/ingest/internal/common/parquet.go
@@ -29,8 +29,8 @@ func HitToExtractPost(hit Hit) ExtractPost {
 		ReplyRootURI:    hit.Source.ThreadRootPost,
 	}
 
-	// Encode embeddings if present. embeddingsFromHit prefers the "fields" API
-	// over _source since posts/replies templates exclude "embeddings" from
+	// Encode embeddings if present. embeddingsFromHit prefers the "docvalue_fields"
+	// API over _source since posts/replies templates exclude "embeddings" from
 	// _source (api#312 step 2).
 	if hitEmbeddings := embeddingsFromHit(hit); len(hitEmbeddings) > 0 {
 		extractPost.Embeddings = make(map[string]string, len(hitEmbeddings))

--- a/ingest/internal/common/parquet.go
+++ b/ingest/internal/common/parquet.go
@@ -29,10 +29,12 @@ func HitToExtractPost(hit Hit) ExtractPost {
 		ReplyRootURI:    hit.Source.ThreadRootPost,
 	}
 
-	// Encode embeddings if present
-	if len(hit.Source.Embeddings) > 0 {
-		extractPost.Embeddings = make(map[string]string, len(hit.Source.Embeddings))
-		for modelName, floatArray := range hit.Source.Embeddings {
+	// Encode embeddings if present. embeddingsFromHit prefers the "fields" API
+	// over _source since posts/replies templates exclude "embeddings" from
+	// _source (api#312 step 2).
+	if hitEmbeddings := embeddingsFromHit(hit); len(hitEmbeddings) > 0 {
+		extractPost.Embeddings = make(map[string]string, len(hitEmbeddings))
+		for modelName, floatArray := range hitEmbeddings {
 			if encoded, err := embeddings.Encode(floatArray); err == nil {
 				extractPost.Embeddings[modelName] = encoded
 			}

--- a/tools/reindex.py
+++ b/tools/reindex.py
@@ -281,7 +281,10 @@ async def _start_reindex(
         _warn(
             f"  Refusing to reindex {src}: its mapping excludes 'embeddings' from _source. "
             f"_reindex only copies _source, so the destination would silently end up with no "
-            f"vector data for that field. This index cannot be migrated with a plain reindex."
+            f"vector data for that field. For shard-count changes use the segment-level "
+            f"_shrink (divisor targets) or _split (multiple targets) APIs instead — they "
+            f"preserve vector data regardless of _source. True mapping changes need a "
+            f"client-side copy that merges _source with fields-API vector retrieval."
         )
         return FAILED
 

--- a/tools/reindex.py
+++ b/tools/reindex.py
@@ -203,6 +203,25 @@ async def _index_exists(es: AsyncElasticsearch, index: str) -> bool:
         return False
 
 
+async def _source_excludes_embeddings(es: AsyncElasticsearch, index: str) -> bool:
+    """Return True if index's mapping excludes "embeddings" from _source.
+
+    Once _source excludes embeddings, dense_vector data only lives in Lucene's
+    indexed/doc-value structures, not in _source. _reindex reads _source, so
+    migrating such an index would silently produce a destination with the
+    embeddings fields entirely unpopulated.
+    """
+    try:
+        mapping = await es.indices.get_mapping(index=index)
+    except NotFoundError:
+        return False
+    for info in mapping.values():
+        excludes = info.get("mappings", {}).get("_source", {}).get("excludes", [])
+        if "embeddings" in excludes:
+            return True
+    return False
+
+
 async def _doc_count(es: AsyncElasticsearch, index: str) -> int | None:
     """Return the document count for index, or None if it does not exist."""
     try:
@@ -257,6 +276,15 @@ async def _start_reindex(
 ) -> str:
     """Kick off an async sliced reindex. Returns REINDEXING or FAILED."""
     dst = state.indices[src].dst
+
+    if await _source_excludes_embeddings(es, src):
+        _warn(
+            f"  Refusing to reindex {src}: its mapping excludes 'embeddings' from _source. "
+            f"_reindex only copies _source, so the destination would silently end up with no "
+            f"vector data for that field. This index cannot be migrated with a plain reindex."
+        )
+        return FAILED
+
     _info(f"  Starting async reindex (slices=auto, 2000 req/s) ...")
 
     try:

--- a/tools/test_reindex.py
+++ b/tools/test_reindex.py
@@ -59,6 +59,63 @@ async def test_doc_count_missing_returns_none():
 
 
 # ---------------------------------------------------------------------------
+# _source_excludes_embeddings
+# ---------------------------------------------------------------------------
+
+async def test_source_excludes_embeddings_true():
+    es = _es()
+    es.indices.get_mapping.return_value = {
+        "posts-2026-w30-abc1234": {"mappings": {"_source": {"excludes": ["embeddings"]}}}
+    }
+    assert await reindex._source_excludes_embeddings(es, "posts-2026-w30-abc1234") is True
+
+
+async def test_source_excludes_embeddings_false_when_absent():
+    es = _es()
+    es.indices.get_mapping.return_value = {
+        "posts-2026-w30": {"mappings": {}}
+    }
+    assert await reindex._source_excludes_embeddings(es, "posts-2026-w30") is False
+
+
+async def test_source_excludes_embeddings_false_for_other_excludes():
+    es = _es()
+    es.indices.get_mapping.return_value = {
+        "posts-2026-w30": {"mappings": {"_source": {"excludes": ["some_other_field"]}}}
+    }
+    assert await reindex._source_excludes_embeddings(es, "posts-2026-w30") is False
+
+
+async def test_source_excludes_embeddings_false_when_index_missing():
+    es = _es()
+    es.indices.get_mapping.side_effect = _nf()
+    assert await reindex._source_excludes_embeddings(es, "missing") is False
+
+
+# ---------------------------------------------------------------------------
+# _start_reindex — vector-drop guard
+# ---------------------------------------------------------------------------
+
+async def test_start_reindex_refuses_when_source_excludes_embeddings(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=PENDING)
+    monkeypatch.setattr(reindex, "_source_excludes_embeddings", AsyncMock(return_value=True))
+
+    assert await reindex._start_reindex(es, st, "s") == FAILED
+    es.reindex.assert_not_awaited()
+
+
+async def test_start_reindex_proceeds_when_source_does_not_exclude_embeddings(monkeypatch):
+    es = _es()
+    st = _state("s", "d", status=PENDING)
+    monkeypatch.setattr(reindex, "_source_excludes_embeddings", AsyncMock(return_value=False))
+    es.reindex.return_value = {"task": "node1:99"}
+
+    assert await reindex._start_reindex(es, st, "s") == REINDEXING
+    es.reindex.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
 # _task_running
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes greenearth-social/api#312

This is step 2 of the ES memory-pressure investigation/plan posted on that issue (steps 0 and 1 are tracked separately; step 0 is #425). `_source` on `posts` is ~65% of the index (raw JSON of three embedding families), so hydration-by-`at_uri` churns page cache. `all_MiniLM_L6_v2` in particular is written by ingex but read by nothing in api.

# This PR

- Stop decoding/storing `all_MiniLM_L6_v2` in `parseInferences` (`ingest/internal/common/megastream_message.go`) — it was written to the doc but never read downstream.
- Add `"_source": {"excludes": ["embeddings"]}` to the `posts` and `replies` index templates. Takes effect at the next weekly rollover; vectors stay indexed/kNN-searchable where applicable, they just stop being duplicated into `_source`. Old fat indices age out via the existing 60d ILM policy.
- Add a guard to `tools/reindex.py`: `_reindex` only copies `_source`, so migrating an index whose mapping already excludes `embeddings` from `_source` would silently produce a destination with no vector data for that field. `_start_reindex` now checks the source mapping via `_source_excludes_embeddings` and refuses (returns `FAILED`) instead of running a lossy reindex. The error message points operators at `_shrink`/`_split` (vector-safe, native ES ops) for shard-count changes, and a client-side `_source`+fields-API merge for true mapping changes if one is ever needed.
- **Fix the `extract` (Parquet export) service, the other in-repo consumer of `_source.embeddings`.** `cmd/extract` builds ML training exports via `common.FetchPosts` → `HitToExtractPost`, which read `hit.Source.Embeddings` straight from `_source` with no fallback — once the exclude rolls out, every post/reply in a new index would silently export `embeddings: nil` in Parquet. `FetchPosts` now also requests `"fields": ["embeddings.*"]` (the same fields-retrieval approach api's step 1 verified works on old and new indices), and a new `embeddingsFromHit` helper prefers the fields-API result over `_source`, falling back to `_source` when fields come back empty (older ES / no vectors). `HitToExtractPost` now goes through this helper instead of reading `_source` directly.
- **Stop kNN-indexing `all_MiniLM_L12_v2` in the `posts` template** (`index: true` → `index: false`, similarity dropped), per the latest comment on api#312: the similarity candidate generator is retired and nothing queries against this field anymore. It's still stored/retrievable — MRR re-ranking hydrates it downstream via the fields API (unaffected by `index: false`, since fields retrieval reads doc-value data regardless of whether a field is kNN-indexed). `replies` already had `index: false` for this field, so only `posts` needed the change.

# Testing

- `go test ./...` in `ingest/` — all packages pass, including:
  - `TestMegaStreamMessage_EmbeddingsParsing` — asserts `all_MiniLM_L6_v2` is dropped while `all_MiniLM_L12_v2` still parses.
  - `TestEmbeddingsFromHit` — covers the fields-preferred/`_source`-fallback merge logic (multiple embedding families, no fields, fields present but irrelevant, nothing present).
  - `TestFetchPosts_RequestsEmbeddingsViaFields` — asserts the search query sent to ES includes `"fields": ["embeddings.*"]`.
- `pipenv run pytest` in `tools/` — all 42 tests pass, including new coverage for `_source_excludes_embeddings` and the `_start_reindex` guard.
- Validated both updated index template YAMLs still embed well-formed JSON (parsed with placeholder substitution for the `$(...)` shard/replica vars), including the `posts` embeddings mapping after the `all_MiniLM_L12_v2` index-flag change.