### PR TITLE
Report git sha on health endpoints and tag ingex revisions

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -234,6 +234,35 @@ export GE_ELASTICSEARCH_API_KEY="asdvnasdfdsa=="
 
 See `./scripts/gc_setup.sh` and `./scripts/deploy.sh`
 
+### Git sha traceability
+
+So we always know what code is live, `deploy.sh` stamps the short git sha of the
+deployed code (`GIT_SHA`) onto every service and job in two places:
+
+- **Env var `GE_GIT_SHA`** — each binary reports it on its health endpoint (see
+  below) and prefixes it onto every log line.
+- **Cloud Run label `git-sha=<sha>`** — tags the service/revision (and job) so
+  past deployments are identifiable when choosing a rollback target:
+
+  ```bash
+  gcloud run revisions list --service=jetstream-ingest-prod --region=us-east1 \
+    --format='value(metadata.name,metadata.labels.git-sha)'
+  ```
+
+### Health endpoint
+
+Every service and job runs a small health server (`internal/common/health.go`)
+on port 8080 (falling back up to 8089). It serves `/health`, `/healthz`,
+`/ready`, and `/`. The JSON payload includes the deployed sha, so you can confirm
+which revision is live and pin it in bug reports:
+
+```json
+{"healthy": true, "status": "healthy", "started_at": "…", "git_sha": "e9f07f5"}
+```
+
+`git_sha` is omitted when running unstamped code (e.g. local dev, where
+`GE_GIT_SHA` is unset).
+
 ## Development
 
 ### Code Organization

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -236,8 +236,12 @@ See `./scripts/gc_setup.sh` and `./scripts/deploy.sh`
 
 ### Git sha traceability
 
-So we always know what code is live, `deploy.sh` stamps the short git sha of the
-deployed code (`GIT_SHA`) onto every service and job in two places:
+So the stamped sha always matches what ships, `deploy.sh` **refuses to deploy
+with a dirty working tree** (uncommitted changes). Deploying an unpushed branch
+is fine — only a dirty tree is rejected. Commit or stash first.
+
+It then stamps the short git sha of the deployed code (`GIT_SHA`) onto every
+service and job in two places:
 
 - **Env var `GE_GIT_SHA`** — each binary reports it on its health endpoint (see
   below) and prefixes it onto every log line.

--- a/ingest/internal/common/health.go
+++ b/ingest/internal/common/health.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 )
@@ -16,6 +17,10 @@ type HealthStatus struct {
 	Status    string    `json:"status"`
 	StartedAt time.Time `json:"started_at"`
 	Message   string    `json:"message,omitempty"`
+	// GitSHA is the short git sha of the deployed code (from GE_GIT_SHA). It lets
+	// us confirm which revision is live and pick rollback targets. Empty when the
+	// code is running unstamped (e.g. local dev).
+	GitSHA string `json:"git_sha,omitempty"`
 }
 
 // HealthServer manages the HTTP health check endpoint
@@ -26,6 +31,7 @@ type HealthServer struct {
 	healthy   bool
 	startedAt time.Time
 	message   string
+	gitSHA    string
 	logger    *IngestLogger
 }
 
@@ -37,6 +43,7 @@ func NewHealthServer(port int, maxPort int, logger *IngestLogger) (*HealthServer
 		startedAt: time.Now(),
 		healthy:   false,
 		message:   "Initializing...",
+		gitSHA:    os.Getenv("GE_GIT_SHA"),
 		logger:    logger,
 	}
 
@@ -120,6 +127,7 @@ func (hs *HealthServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 		Status:    hs.getStatusString(),
 		StartedAt: hs.startedAt,
 		Message:   hs.message,
+		GitSHA:    hs.gitSHA,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -159,6 +167,7 @@ func (hs *HealthServer) handleRoot(w http.ResponseWriter, r *http.Request) {
 		Status:    hs.getStatusString(),
 		StartedAt: hs.startedAt,
 		Message:   hs.message,
+		GitSHA:    hs.gitSHA,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/ingest/internal/common/health_test.go
+++ b/ingest/internal/common/health_test.go
@@ -201,6 +201,29 @@ func TestHealthServer_Endpoints(t *testing.T) {
 	}
 }
 
+func TestHealthServer_ReportsGitSHA(t *testing.T) {
+	t.Setenv("GE_GIT_SHA", "e9f07f5")
+	logger := NewLogger(false)
+
+	hs, err := NewHealthServer(9060, 9069, logger)
+	if err != nil {
+		t.Fatalf("Failed to create health server: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = hs.Start(ctx) // Error logged by Start itself
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	status := getHealthStatus(t, hs.GetPort())
+	if status.GitSHA != "e9f07f5" {
+		t.Errorf("Expected git_sha 'e9f07f5', got '%s'", status.GitSHA)
+	}
+}
+
 func TestHealthServer_PortRetry(t *testing.T) {
 	logger := NewLogger(false)
 

--- a/ingest/scripts/deploy.sh
+++ b/ingest/scripts/deploy.sh
@@ -21,8 +21,10 @@ GE_AWS_S3_PREFIX="${GE_AWS_S3_PREFIX:-mega/}"
 GE_JETSTREAM_INSTANCES="${GE_JETSTREAM_INSTANCES:-1}"
 GE_MEGASTREAM_INSTANCES="${GE_MEGASTREAM_INSTANCES:-1}"
 
-# Get current git SHA (short version) for deployment tracking
-GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+# Short git SHA of the deployed code, resolved by require_clean_worktree().
+# Stamped onto every Cloud Run service/job (env var + git-sha label) so we can
+# identify exactly what code is live.
+GIT_SHA=""
 
 # Colors for output
 RED='\033[0;31m'
@@ -84,6 +86,29 @@ cleanup_old_revisions() {
             done
         fi
     fi
+}
+
+require_clean_worktree() {
+    log_info "Verifying git working tree is clean..."
+
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        log_error "Not inside a git repository — cannot verify the deployed code."
+        log_error "Run deploy.sh from a checkout of the ingex repo."
+        exit 1
+    fi
+
+    # Refuse to deploy with uncommitted changes so the stamped git sha always
+    # matches the code that ships. Deploying an unpushed branch is fine — only a
+    # dirty tree is rejected.
+    if [ -n "$(git status --porcelain)" ]; then
+        log_error "Working tree has uncommitted changes. Commit or stash them before deploying"
+        log_error "so the deployed git sha reflects the running code."
+        git status --short
+        exit 1
+    fi
+
+    GIT_SHA="$(git rev-parse --short HEAD)"
+    log_info "Deploying git sha: $GIT_SHA ($(git rev-parse --abbrev-ref HEAD))"
 }
 
 validate_config() {
@@ -488,6 +513,9 @@ show_service_status() {
 
 main() {
     local service="${1:-all}"
+
+    # Refuse to deploy a dirty tree and resolve GIT_SHA before anything uses it.
+    require_clean_worktree
 
     # Derive GE_INDEX_PERIOD from GE_ENVIRONMENT after all flags have been parsed.
     # Using unconditional assignment so a stale GE_INDEX_PERIOD in the caller's

--- a/ingest/scripts/deploy.sh
+++ b/ingest/scripts/deploy.sh
@@ -217,6 +217,7 @@ deploy_jetstream_service() {
         --set-env-vars="GE_LIKE_RATE_LIMIT_PER_HOUR=600" \
         --set-env-vars="GE_INDEX_PERIOD=$GE_INDEX_PERIOD" \
         --set-secrets="GE_ELASTICSEARCH_API_KEY=$es_api_key_secret:latest" \
+        --labels="git-sha=$GIT_SHA" \
         --scaling="$GE_JETSTREAM_INSTANCES" \
         --cpu=1 \
         --memory=512Mi \
@@ -288,6 +289,7 @@ deploy_megastream_service() {
         --set-env-vars="GE_INDEX_PERIOD=$GE_INDEX_PERIOD" \
         --set-env-vars="GE_INFERENCE_BASE_URL=$inference_base_url" \
         --set-secrets="GE_ELASTICSEARCH_API_KEY=$es_api_key_secret:latest,GE_AWS_S3_ACCESS_KEY=$aws_access_key_secret:latest,GE_AWS_S3_SECRET_KEY=$aws_secret_key_secret:latest,GE_INFERENCE_API_KEY=$inference_api_key_secret:latest" \
+        --labels="git-sha=$GIT_SHA" \
         --scaling="$GE_MEGASTREAM_INSTANCES" \
         --cpu=1 \
         --memory=1Gi \
@@ -380,6 +382,7 @@ EOF
         --set-env-vars="GE_ENVIRONMENT=$GE_ENVIRONMENT" \
         --set-env-vars="GE_GCP_REGION=$GE_GCP_REGION" \
         --set-env-vars="GE_METRIC_EXPORT_INTERVAL_SEC=60" \
+        --labels="git-sha=$GIT_SHA" \
         --cpu=1 \
         --memory=512Mi \
         --task-timeout=3600 \
@@ -438,6 +441,7 @@ deploy_extract_job() {
         --set-env-vars="GE_ENVIRONMENT=$GE_ENVIRONMENT" \
         --set-env-vars="GE_GCP_REGION=$GE_GCP_REGION" \
         --set-env-vars="GE_METRIC_EXPORT_INTERVAL_SEC=60" \
+        --labels="git-sha=$GIT_SHA" \
         --cpu=2 \
         --memory=4Gi \
         --task-timeout=7200 \


### PR DESCRIPTION
Extends the deployed-sha traceability added to the `api` repo (greenearth-social/api#349, issue api#228) to ingex, so we can tell exactly which code is behind a running ingest service — and keep a stamped sha from ever lying about it.

## Changes
- **Clean-tree deploys** — `deploy.sh` now refuses to deploy with a dirty working tree and resolves `GIT_SHA` from it, so the stamped sha always matches what ships. Deploying an unpushed branch is still fine — only a dirty tree is rejected.
- **Health endpoint reports the sha** — the shared health server (`internal/common/health.go`) now includes `git_sha` (from `GE_GIT_SHA`) in the `/health`, `/healthz`, and `/` JSON payloads. All four binaries (jetstream, megastream, expiry, extract) use `common.NewHealthServer`, so this covers every service and job in one place. Omitted when running unstamped (local dev).
- **Revision tagging for rollbacks** — `deploy.sh` adds a `git-sha=<sha>` label to every Cloud Run service and job. (The `GE_GIT_SHA` env var was already set on each.)
- **Docs** — README documents the clean-tree requirement, the health payload, and the deploy-time tagging, with a `gcloud run revisions list` example for finding a rollback target.

Example `/health` payload:
```json
{"healthy": true, "status": "healthy", "started_at": "…", "git_sha": "e9f07f5"}
```

## Testing
`go build ./...`, `go test -race ./internal/common/...`, `go vet`, `gofmt`, and `golangci-lint run` all clean. Added `TestHealthServer_ReportsGitSHA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)