### PR TITLE
Migrate ES client to functional-options constructor

### DIFF
--- a/ingest/go.mod
+++ b/ingest/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.43.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.32
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
+	github.com/elastic/elastic-transport-go/v8 v8.9.0
 	github.com/elastic/go-elasticsearch/v9 v9.4.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/parquet-go/parquet-go v0.29.0
@@ -49,7 +50,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/elastic/elastic-transport-go/v8 v8.9.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/ingest/internal/common/elasticsearch.go
+++ b/ingest/internal/common/elasticsearch.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 	"github.com/elastic/go-elasticsearch/v9"
 )
 
@@ -167,21 +168,23 @@ type ElasticsearchConfig struct {
 
 // NewElasticsearchClient creates and tests a new Elasticsearch client
 func NewElasticsearchClient(config ElasticsearchConfig, logger *IngestLogger) (*elasticsearch.Client, error) {
-	esConfig := elasticsearch.Config{
-		Addresses: []string{config.URL},
-		APIKey:    config.APIKey,
+	opts := []elasticsearch.Option{
+		elasticsearch.WithAddresses(config.URL),
+		elasticsearch.WithAPIKey(config.APIKey),
 	}
 
 	if config.SkipTLSVerify {
 		logger.Info("TLS certificate verification disabled (local development mode)")
-		esConfig.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, // nolint:gosec // G402: Required for local development with self-signed certs
-			},
-		}
+		opts = append(opts, elasticsearch.WithTransportOptions(
+			elastictransport.WithTransport(&http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, // nolint:gosec // G402: Required for local development with self-signed certs
+				},
+			}),
+		))
 	}
 
-	client, err := elasticsearch.NewClient(esConfig)
+	client, err := elasticsearch.New(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Elasticsearch client: %w", err)
 	}

--- a/ingest/internal/common/elasticsearch_ensure_index_test.go
+++ b/ingest/internal/common/elasticsearch_ensure_index_test.go
@@ -25,9 +25,7 @@ func (m *mockESHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func newMockESClient(t *testing.T, handler http.Handler) (*elasticsearch.Client, *httptest.Server) {
 	t.Helper()
 	srv := httptest.NewServer(handler)
-	client, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses: []string{srv.URL},
-	})
+	client, err := elasticsearch.New(elasticsearch.WithAddresses(srv.URL))
 	if err != nil {
 		srv.Close()
 		t.Fatalf("failed to create mock ES client: %v", err)
@@ -84,7 +82,7 @@ func TestEnsureIndex_ResourceAlreadyExists_IsNotAnError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := elasticsearch.NewClient(elasticsearch.Config{Addresses: []string{srv.URL}})
+	client, err := elasticsearch.New(elasticsearch.WithAddresses(srv.URL))
 	if err != nil {
 		t.Fatalf("failed to create ES client: %v", err)
 	}


### PR DESCRIPTION
The go-elasticsearch v9.4.1 bump (#367) deprecated `elasticsearch.Config` and `elasticsearch.NewClient`, tripping `staticcheck` (SA1019) in CI. This migrates to the functional-options constructor `elasticsearch.New(...Option)`.

- `NewElasticsearchClient` now builds `[]elasticsearch.Option` (`WithAddresses`, `WithAPIKey`); the `SkipTLSVerify` path routes the custom TLS transport through `WithTransportOptions(elastictransport.WithTransport(...))`, preserving prior behavior.
- Test helpers switched to `elasticsearch.New(elasticsearch.WithAddresses(...))`.
- `go mod tidy` promoted `elastic-transport-go/v8` from indirect to direct, since it's now imported directly.

`golangci-lint run` is clean and `go test ./internal/common/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)